### PR TITLE
Specify type on RequestHandler in index.ts

### DIFF
--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -33,7 +33,7 @@ async function main() {
       tool.name,
       tool.description,
       tool.arguments.shape,
-      async (args: any, _extra: RequestHandlerExtra) => {
+      async (args: any, _extra: RequestHandlerExtra <any, any>) => {
         const result = await tool.invoke(adyenClient, args);
         return {
           content: [


### PR DESCRIPTION
`npm run build` fails because the type is not specified in the `RequestHandler` in `index.ts`