### PR TITLE
Add license and repository to package.json

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -24,5 +24,10 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "typescript": "^5.0.0"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Adyen/adyen-mcp.git"
   }
 }


### PR DESCRIPTION
## Summary
This pull request adds the `license` and `repository` fields to `package.json`.
- **Motivation**: To clearly define the licensing terms of the project and provide a direct link to the source code repository.

## Tested scenarios
N/A - This change only involves adding metadata to `package.json` and does not affect the runtime behavior or functionality of the application.

**Fixed issue**: N/A