### PR TITLE
Release adyen-mcp-server 0.2.1

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adyen/mcp",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": "dist/index.js",
   "engines": {
     "node": ">=18"

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -9,7 +9,7 @@ import { Environment, getAdyenConfig } from "./configurations/configurations";
 
 const APPLICATION_NAME = "adyen-mcp-server";
 const APP_NAME = "Adyen MCP";
-const APP_VERSION = "0.2.0";
+const APP_VERSION = "0.2.1";
 
 async function main() {
   const adyenConfig = getAdyenConfig();


### PR DESCRIPTION
This release (0.2.1) addresses an incorrectly specified `returnUrl` in the example. [see this commit](https://github.com/Adyen/adyen-mcp/commit/a3536aabdbc2197db9e7be6112842fb59cbc3ab7)