### PR TITLE
Add test coverage to cli parameters

### DIFF
--- a/typescript/jest.config.js
+++ b/typescript/jest.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src', '<rootDir>/test'],
+  testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
+  transform: {
+    '^.+\\.ts$': 'ts-jest',
+  },
+  collectCoverageFrom: [
+    'src/**/*.ts',
+    '!src/**/*.d.ts',
+  ],
+  coverageDirectory: 'coverage',
+  coverageReporters: ['text', 'lcov', 'html'],
+};

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -15,7 +15,9 @@
   ],
   "scripts": {
     "build": "tsc",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "test": "jest",
+    "test:coverage": "jest --coverage"
   },
   "dependencies": {
     "@adyen/api-library": "^27.0.0",
@@ -23,7 +25,10 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@types/jest": "^29.5.0",
     "@types/node": "^22.0.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.0",
     "typescript": "^5.0.0"
   },
   "license": "MIT",

--- a/typescript/test/configurations.test.ts
+++ b/typescript/test/configurations.test.ts
@@ -1,0 +1,175 @@
+import { getAdyenConfig } from '../src/configurations/configurations';
+
+describe('configurations', () => {
+  // Store original process.argv to restore after tests
+  const originalArgv = process.argv;
+
+  afterEach(() => {
+    // Restore original process.argv after each test
+    process.argv = originalArgv;
+  });
+
+  describe('getAdyenConfig', () => {
+    describe('valid configurations', () => {
+      it('should parse valid TEST environment config', () => {
+        const args = ['--adyenApiKey', 'test-api-key', '--env', 'TEST'];
+        const config = getAdyenConfig(args);
+
+        expect(config.adyenApiKey).toBe('test-api-key');
+        expect(config.env).toBe('TEST');
+      });
+
+      it('should parse valid LIVE environment config with livePrefix', () => {
+        const args = [
+          '--adyenApiKey', 'live-api-key',
+          '--env', 'LIVE',
+          '--livePrefix', 'https://example.adyen.com'
+        ];
+        const config = getAdyenConfig(args);
+
+        expect(config.adyenApiKey).toBe('live-api-key');
+        expect(config.env).toBe('LIVE');
+        expect(config.livePrefix).toBe('https://example.adyen.com');
+      });
+
+      it('should use TEST as default environment when not specified', () => {
+        const args = ['--adyenApiKey', 'test-api-key'];
+        const config = getAdyenConfig(args);
+
+        expect(config.adyenApiKey).toBe('test-api-key');
+        expect(config.env).toBe('TEST');
+      });
+
+      it('should parse config with optional livePrefix for TEST environment', () => {
+        const args = [
+          '--adyenApiKey', 'test-api-key',
+          '--env', 'TEST',
+          '--livePrefix', 'some-prefix'
+        ];
+        const config = getAdyenConfig(args);
+
+        expect(config.adyenApiKey).toBe('test-api-key');
+        expect(config.env).toBe('TEST');
+        expect(config.livePrefix).toBe('some-prefix');
+      });
+    });
+
+    describe('validation errors', () => {
+      it('should throw error when apiKey is missing', () => {
+        const args = ['--env', 'TEST'];
+        
+        expect(() => getAdyenConfig(args)).toThrow(/adyenApiKey/i);
+      });
+
+      it('should throw error when apiKey is empty string', () => {
+        const args = ['--adyenApiKey', '', '--env', 'TEST'];
+        
+        expect(() => getAdyenConfig(args)).toThrow(/adyenApiKey/i);
+      });
+
+      it('should throw error when environment is invalid', () => {
+        const args = ['--adyenApiKey', 'test-key', '--env', 'INVALID'];
+        
+        expect(() => getAdyenConfig(args)).toThrow(/environment.*invalid/i);
+      });
+
+      it('should throw error when LIVE environment is used without livePrefix', () => {
+        const args = ['--adyenApiKey', 'live-key', '--env', 'LIVE'];
+        
+        expect(() => getAdyenConfig(args)).toThrow(/prefix.*live/i);
+      });
+
+      it('should throw error when LIVE environment has empty livePrefix', () => {
+        const args = ['--adyenApiKey', 'live-key', '--env', 'LIVE', '--livePrefix', ''];
+        
+        expect(() => getAdyenConfig(args)).toThrow(/prefix.*live/i);
+      });
+
+      it('should throw error for unknown arguments when strict mode is enabled', () => {
+        const args = ['--adyenApiKey', 'test-key', '--env', 'TEST', '--unknownArg', 'value'];
+        
+        expect(() => getAdyenConfig(args)).toThrow();
+      });
+
+      it('should throw error for positional arguments', () => {
+        const args = ['--adyenApiKey', 'test-key', '--env', 'TEST', 'positional-arg'];
+        
+        expect(() => getAdyenConfig(args)).toThrow();
+      });
+    });
+
+    describe('error handling and logging', () => {
+      let consoleSpy: jest.SpyInstance;
+
+      beforeEach(() => {
+        consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      });
+
+      afterEach(() => {
+        consoleSpy.mockRestore();
+      });
+
+      it('should log error message and usage examples when parsing fails', () => {
+        const args = ['--adyenApiKey', 'test-key', '--env', 'INVALID'];
+        
+        expect(() => getAdyenConfig(args)).toThrow();
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringMatching(/error.*parsing/i));
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringMatching(/usage.*example/i));
+      });
+
+      it('should log appropriate error for missing required fields', () => {
+        const args = ['--env', 'TEST'];
+        
+        expect(() => getAdyenConfig(args)).toThrow();
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringMatching(/adyenApiKey/i));
+      });
+    });
+
+    describe('edge cases', () => {
+      it('should handle empty args array', () => {
+        const args: string[] = [];
+        
+        // Should use default TEST environment but fail on missing API key
+        expect(() => getAdyenConfig(args)).toThrow(/adyenApiKey/i);
+      });
+
+      it('should handle null values', () => {
+        // This tests the internal validation logic for null values
+        const args = ['--adyenApiKey', 'test-key', '--env', 'TEST'];
+        const config = getAdyenConfig(args);
+        
+        expect(config).toBeDefined();
+        expect(config.adyenApiKey).toBe('test-key');
+      });
+
+      it('should handle case sensitivity for environment values', () => {
+        const args = ['--adyenApiKey', 'test-key', '--env', 'test'];
+        
+        expect(() => getAdyenConfig(args)).toThrow(/environment.*test/i);
+      });
+    });
+
+    describe('default process.argv behavior', () => {
+      it('should use process.argv when no args provided', () => {
+        // Mock process.argv
+        process.argv = ['node', 'script.js', '--adyenApiKey', 'default-key', '--env', 'TEST'];
+        
+        const config = getAdyenConfig();
+        
+        expect(config.adyenApiKey).toBe('default-key');
+        expect(config.env).toBe('TEST');
+      });
+
+      it('should slice process.argv correctly', () => {
+        // Mock process.argv with typical node command structure
+        process.argv = ['node', '/path/to/script.js', '--adyenApiKey', 'argv-key', '--env', 'LIVE', '--livePrefix', 'live-prefix'];
+        
+        const config = getAdyenConfig();
+        
+        expect(config.adyenApiKey).toBe('argv-key');
+        expect(config.env).toBe('LIVE');
+        expect(config.livePrefix).toBe('live-prefix');
+      });
+    });
+  });
+});


### PR DESCRIPTION
**Description**
This MR pushes the tests for the CLI commands and sets up the test environment

```md
-------------------------|---------|----------|---------|---------|-------------------
File                     | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------------------|---------|----------|---------|---------|-------------------
All files                |   15.26 |    92.85 |      25 |   15.26 |                   
 src                     |       0 |        0 |       0 |       0 |                   
  index.ts               |       0 |        0 |       0 |       0 | 3-61              
 src/configurations      |     100 |      100 |     100 |     100 |                   
  configurations.ts      |     100 |      100 |     100 |     100 |                   
  ```

**Tested scenarios**
<!-- Description of tested scenarios -->
```
 PASS  test/configurations.test.ts
  configurations
    getAdyenConfig
      valid configurations
        ✓ should parse valid TEST environment config (2 ms)
        ✓ should parse valid LIVE environment config with livePrefix
        ✓ should use TEST as default environment when not specified (1 ms)
        ✓ should parse config with optional livePrefix for TEST environment
      validation errors
        ✓ should throw error when apiKey is missing (26 ms)
        ✓ should throw error when apiKey is empty string (6 ms)
        ✓ should throw error when environment is invalid (5 ms)
        ✓ should throw error when LIVE environment is used without livePrefix (4 ms)
        ✓ should throw error when LIVE environment has empty livePrefix (6 ms)
        ✓ should throw error for unknown arguments when strict mode is enabled (5 ms)
        ✓ should throw error for positional arguments (4 ms)
      error handling and logging
        ✓ should log error message and usage examples when parsing fails (1 ms)
        ✓ should log appropriate error for missing required fields
      edge cases
        ✓ should handle empty args array (4 ms)
        ✓ should handle null values (1 ms)
        ✓ should handle case sensitivity for environment values (3 ms)
      default process.argv behavior
        ✓ should use process.argv when no args provided (2 ms)
        ✓ should slice process.argv correctly
        ```
