### PR TITLE
Adding GET merchant webhooks from Management API

### DIFF
--- a/typescript/README.md
+++ b/typescript/README.md
@@ -15,7 +15,7 @@ The Adyen Model Context Protocol server allows you to integrate with Adyen APIs 
    - Refunds a captured payment
 5. Management API
    - Gets a list of merchant accounts for your company account
-
+   - Gets a list of webhooks associated to your merchant account
 
 ### Usage
 To run to the MCP server via `npx` you can execute:
@@ -35,6 +35,7 @@ npx -y @adyen/mcp --adyenApiKey=YOUR_ADYEN_API_KEY --env=LIVE --livePrefix=YOUR_
 * Management API - Payment methods Read
 * Checkout Webservice Role
 * Merchant PAL Webservice Role
+* Management API - Webhooks read
 
 Adyen recommends creating a new webservice user and generating a new API key for the purpose of this application.
 Only use the new user’s API key for the MCP application and limit the roles to match the tools you'll be using. 

--- a/typescript/src/tools/management/constants.ts
+++ b/typescript/src/tools/management/constants.ts
@@ -14,3 +14,15 @@ export const GET_MERCHANT_ACCOUNTS_DESCRIPTION = `
     Args:
         merchantId (str): The unique identifier of the merchant account.
    `;
+
+export const LIST_MERCHANT_WEBHOOKS_NAME = "list_merchant_webhooks";
+export const LIST_MERCHANT_WEBHOOKS_DESCRIPTION = `
+    Get a list of webhooks for a specific merchant account
+
+    Args:
+        merchantId (str): The unique identifier of the merchant account.
+        pageSize (int): The number of items to have on a page, maximum 100. The default is 10 items on a page.
+        pageNumber (int): The number of the page to fetch.
+   `;
+
+   

--- a/typescript/src/tools/management/index.ts
+++ b/typescript/src/tools/management/index.ts
@@ -5,6 +5,8 @@ import {
   GET_MERCHANT_ACCOUNTS_NAME,
   LIST_MERCHANT_ACCOUNTS_DESCRIPTION,
   LIST_MERCHANT_ACCOUNTS_NAME,
+  LIST_MERCHANT_WEBHOOKS_NAME,
+  LIST_MERCHANT_WEBHOOKS_DESCRIPTION,
 } from "./constants";
 import { Tool } from "../types";
 
@@ -70,5 +72,40 @@ export const getMerchantAccountsTool: Tool = {
   description: GET_MERCHANT_ACCOUNTS_DESCRIPTION,
   arguments: getMerchantAccountRequestObject,
   invoke: getMerchantAccount,
+};
+
+const listMerchantWebhooksRequestShape: z.ZodRawShape = {
+  merchantId: z.string(),
+  pageSize: z.number(),
+  pageNumber: z.number(),
+};
+
+const listMerchantWebhooksRequestObject = z.object(
+    listMerchantWebhooksRequestShape
+);
+
+const listMerchantWebhooks = async (
+    client: Client,
+    listMerchantWebhooksRequest: z.infer<typeof listMerchantWebhooksRequestObject>
+) => {
+  const { merchantId, pageSize, pageNumber } = listMerchantWebhooksRequest;
+
+  const managementAPI = new ManagementAPI(client);
+  try {
+    return await managementAPI.WebhooksMerchantLevelApi.listAllWebhooks(
+        merchantId,
+        pageSize,
+        pageNumber
+    );
+  } catch (e) {
+    return "Failed to get webhooks. Error: " + JSON.stringify(e);
+  }
+};
+
+export const listMerchantWebhooksTool: Tool = {
+  name: LIST_MERCHANT_WEBHOOKS_NAME,
+  description: LIST_MERCHANT_WEBHOOKS_DESCRIPTION,
+  arguments: listMerchantWebhooksRequestObject,
+  invoke: listMerchantWebhooks,
 };
 

--- a/typescript/src/tools/tools.ts
+++ b/typescript/src/tools/tools.ts
@@ -2,7 +2,7 @@ import { createPaymentLinkTool, getPaymentLinkTool, updatePaymentLinkTool } from
 import { Tool } from "./types";
 import {cancelPaymentTool, refundPaymentTool} from "./modifications";
 import {createPaymentSessionTool, getPaymentMethodsTool, getPaymentSessionTool} from "./payments";
-import {getMerchantAccountsTool, listMerchantAccountsTool} from "./management";
+import {getMerchantAccountsTool, listMerchantAccountsTool, listMerchantWebhooksTool} from "./management";
 
 export const tools: Tool[] = [
   createPaymentLinkTool,
@@ -14,5 +14,6 @@ export const tools: Tool[] = [
   getPaymentMethodsTool,
   listMerchantAccountsTool,
   getMerchantAccountsTool,
-  cancelPaymentTool
+  cancelPaymentTool,
+  listMerchantWebhooksTool
 ];


### PR DESCRIPTION
**Description**
Adding GET /merchants/{id}/webhooks endpoint from Management API

**Tested scenarios**
retrieved the list of merchant Webhooks through copilot