### PR TITLE
Release adyen-mcp-server 0.2.2

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adyen/mcp",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "main": "dist/index.js",
   "engines": {
     "node": ">=18"

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -9,7 +9,7 @@ import { Environment, getAdyenConfig } from "./configurations/configurations";
 
 const APPLICATION_NAME = "adyen-mcp-server";
 const APP_NAME = "Adyen MCP";
-const APP_VERSION = "0.2.1";
+const APP_VERSION = "0.2.2";
 
 async function main() {
   const adyenConfig = getAdyenConfig();


### PR DESCRIPTION
This release (0.2.2) addresses a mismatch on the documentation for the amount parameter on the `createPaymentLink` tool.