### PR TITLE
fix: point to correct binary location on ts project

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -7,7 +7,7 @@
   },
   "author": "Adyen",
   "bin": {
-    "mcp": "./dist/index.js"
+    "mcp": "./dist/src/index.js"
   },
   "contributors": [
     "Leonardo Galesky <devrel@adyen.com>",


### PR DESCRIPTION
**Description**
This MR fixes the `bin` location for the `mcp` command in `package.json`, which was pointing to the wrong file. The path has been updated to point to the correct entrypoint after the build process.

**Tested scenarios**
- Verified the fix by running `npm pack` to create a tarball.
- Executed the command from the tarball using `npx adyen-mcp-0.2.2.tgz` to ensure it works as expected.
- Also tested with `npm link` and starting a clean project