### PR TITLE
Add Management API webhook retrieval tools to the Adyen MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ The [Adyen Model Context Protocol (MCP) server](https://docs.adyen.com/developme
    - Creates a payment link - POST [`/paymentLinks`](https://docs.adyen.com/api-explorer/Checkout/71/post/paymentLinks)
    - Gets the status of a payment link - GET [`/paymentLinks/{linkId}`](https://docs.adyen.com/api-explorer/Checkout/71/get/paymentLinks/(linkId))
    - Updates a payment link (force expiry of the link) - PATCH [`/paymentLinks/{linkId}`](https://docs.adyen.com/api-explorer/Checkout/71/patch/paymentLinks/(linkId))
-4. Checkout API - Modifications
+3. Checkout API - Modifications
    - Cancels an authorized payment - POST [`/payments/{paymentPspReference}/cancels`](https://docs.adyen.com/api-explorer/Checkout/latest/post/payments/(paymentPspReference)/cancels)
    - Refunds a captured payment - POST [`/payments/{paymentPspReference}/refunds`](https://docs.adyen.com/api-explorer/Checkout/latest/post/payments/(paymentPspReference)/refunds)
-5. Management API - Accounts
+4. Management API - Accounts
    - Gets a list of merchant accounts for your company account - GET [`/merchants`](https://docs.adyen.com/api-explorer/Management/latest/get/merchants)
-6. Management API - Terminals
+5. Management API - Terminals
    - Gets a list of terminals - GET [`/terminals`](https://docs.adyen.com/api-explorer/Management/3/get/terminals)
    - Reassigns a terminal - POST [`/terminals/{terminalId}/reassign`](https://docs.adyen.com/api-explorer/Management/3/post/terminals/(terminalId)/reassign)
    - Gets a list of Android apps - GET [`/companies/{companyId}/androidApps`](https://docs.adyen.com/api-explorer/Management/3/get/companies/(companyId)/androidApps)
@@ -25,6 +25,11 @@ The [Adyen Model Context Protocol (MCP) server](https://docs.adyen.com/developme
    - Gets a list of terminal actions - GET [`/companies/{companyId}/terminalActions`](https://docs.adyen.com/api-explorer/Management/3/get/companies/(companyId)/terminalActions)
    - Gets terminal settings - GET [`/companies/{companyId}/terminalSettings`](https://docs.adyen.com/api-explorer/Management/3/get/companies/(companyId)/terminalSettings)/ GET [`/merchants/{merchantId}/terminalSettings`](https://docs.adyen.com/api-explorer/Management/3/get/merchants/(merchantId)/terminalSettings)/ GET [`/merchants/{merchantId}/stores/{reference}/terminalSettings`](https://docs.adyen.com/api-explorer/Management/3/get/merchants/(merchantId)/stores/(reference)/terminalSettings)/ GET [`/terminals/{terminalId}/terminalSettings`](https://docs.adyen.com/api-explorer/Management/3/get/terminals/(terminalId)/terminalSettings)
    - Updates terminal settings - PATCH [`/companies/{companyId}/terminalSettings`](https://docs.adyen.com/api-explorer/Management/3/patch/companies/(companyId)/terminalSettings)/ PATCH [`/merchants/{merchantId}/terminalSettings`](https://docs.adyen.com/api-explorer/Management/3/patch/merchants/(merchantId)/terminalSettings)/ PATCH [`/merchants/{merchantId}/stores/{reference}/terminalSettings`](https://docs.adyen.com/api-explorer/Management/3/patch/merchants/(merchantId)/stores/(reference)/terminalSettings)/ PATCH [`/terminals/{terminalId}/terminalSettings`](https://docs.adyen.com/api-explorer/Management/3/patch/terminals/(terminalId)/terminalSettings)
+6. Management API - Webhooks
+   - List all webhooks - GET [`/companies/{companyId}/webhooks`](https://docs.adyen.com/api-explorer/Management/3/get/companies/(companyId)/webhooks)
+   - List all webhooks - GET [`/merchants/{merchantId}/webhooks`](https://docs.adyen.com/api-explorer/Management/3/get/merchants/(merchantId)/webhooks)
+   - Get a webhook - GET [`/companies/{companyId}/webhooks/{webhookId}`](https://docs.adyen.com/api-explorer/Management/3/get/companies/(companyId)/webhooks/(webhookId))
+   - Get a webhook - GET [`/merchants/{merchantId}/webhooks/{webhookId}`](https://docs.adyen.com/api-explorer/Management/3/get/merchants/(merchantId)/webhooks/(webhookId))
 
 
 ### Usage
@@ -69,6 +74,7 @@ Example usage in `.vscode`:
 * Management API — Android files read
 * Management API — Terminal settings read
 * Management API — Terminal settings read and write
+* Management API — Webhooks read
 
 Adyen recommends creating a new webservice user and generating a new API key for the purpose of this application.
 Only use the new user’s API key for the MCP application and limit the roles to match the tools you'll be using. 

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -10,12 +10,12 @@ The Adyen Model Context Protocol server allows you to integrate with Adyen APIs 
    - Gets the status of a payment link
    - Create a payment link
    - Updates a payment link (force expiry of the link)
-4. Modifications API - Cancel / Refund 
+3. Modifications API - Cancel / Refund 
    - Cancels an authorized payment
    - Refunds a captured payment
-5. Management API - Accounts
+4. Management API - Accounts
    - Gets a list of merchant accounts for your company account
-6. Management API - Terminals
+5. Management API - Terminals
    - Get a list of terminals
    - Reassign a terminal
    - Get Android app details
@@ -25,12 +25,14 @@ The Adyen Model Context Protocol server allows you to integrate with Adyen APIs 
    - Get a list of terminal actions
    - Get terminal settings
    - Update terminal settings
+6. Management API - Webhooks
+   - List all webhooks
+   - Get a webhook
 7. Configuration API - Account Holders
    - Get account holder details and its capability settings.
 8. Legal entity management API - Legal entities and onboarding links
    - Get legal entity details and its KYC information. 
    - Create an onboarding link for a legal entity. 
-
 
 ### Usage
 To run to the MCP server via `npx` you can execute:
@@ -57,6 +59,7 @@ npx -y @adyen/mcp --adyenApiKey=YOUR_ADYEN_API_KEY --env=LIVE --livePrefix=YOUR_
 * Management API — Android files read
 * Management API — Terminal settings read
 * Management API — Terminal settings read and write
+* Management API — Webhooks read
 
 Adyen recommends creating a new webservice user and generating a new API key for the purpose of this application.
 Only use the new user’s API key for the MCP application and limit the roles to match the tools you'll be using. 

--- a/typescript/src/tools/tools.ts
+++ b/typescript/src/tools/tools.ts
@@ -7,6 +7,12 @@ import { terminalTools } from "./terminals";
 import { createHostedOnboardingLinkTool } from "./legalEntityManagement/onboardingLinks";
 import { getLegalEntityTool } from "./legalEntityManagement/legalEntities";
 import { getAccountHolderTool } from "./configuration/accountHolders";
+import {
+    getCompanyWebhookTool,
+    getMerchantWebhookTool,
+    listAllCompanyWebhooksTool,
+    listAllMerchantWebhooksTool,
+} from "./webhooks";
 
 export const tools: Tool[] = [
   createPaymentLinkTool,
@@ -22,5 +28,9 @@ export const tools: Tool[] = [
   ...terminalTools,
   createHostedOnboardingLinkTool,
   getLegalEntityTool,
-  getAccountHolderTool
+  getAccountHolderTool,
+  listAllCompanyWebhooksTool,
+  getCompanyWebhookTool,
+  listAllMerchantWebhooksTool,
+  getMerchantWebhookTool
 ];

--- a/typescript/src/tools/webhooks/constants.ts
+++ b/typescript/src/tools/webhooks/constants.ts
@@ -1,0 +1,37 @@
+export const LIST_ALL_MERCHANT_WEBHOOKS = "list_all_merchant_webhooks";
+export const LIST_ALL_MERCHANT_WEBHOOKS_DESCRIPTION = `
+    Lists all webhook configurations for the merchant account.
+
+    Args:
+        merchantId (string): The unique identifier of the merchant account.
+        pageSize (int): The number of items to have on a page, maximum 100. The default is 10 items on a page.
+        pageNumber (int): The number of the page to fetch. Default is 1.
+   `;
+
+export const GET_MERCHANT_WEBHOOK = "get_merchant_webhook";
+export const GET_MERCHANT_WEBHOOK_DESCRIPTION = `
+    Returns the configuration for the webhook identified in the path.
+
+    Args:
+        merchantId (string): The unique identifier of the merchant account.
+        webhookId (string): Unique identifier of the webhook configuration.
+   `;
+
+export const LIST_ALL_COMPANY_WEBHOOKS = "list_all_company_webhooks";
+export const LIST_ALL_COMPANY_WEBHOOKS_DESCRIPTION = `
+    Lists all webhook configurations for the company account.
+
+    Args:
+        companyId (string): Unique identifier of the company account.
+        pageSize (int): The number of items to have on a page, maximum 100. The default is 10 items on a page.
+        pageNumber (int): The number of the page to fetch. Default is 1.
+   `;
+
+export const GET_COMPANY_WEBHOOK = "get_company_webhook";
+export const GET_COMPANY_WEBHOOK_DESCRIPTION = `
+    Returns the configuration for the webhook identified in the path.
+
+    Args:
+        companyID (string): Unique identifier of the company account.
+        webhookId (string): Unique identifier of the webhook configuration.
+   `;

--- a/typescript/src/tools/webhooks/index.ts
+++ b/typescript/src/tools/webhooks/index.ts
@@ -1,0 +1,145 @@
+import { z } from "zod";
+import { Client, ManagementAPI } from "@adyen/api-library";
+import { Tool } from "../types";
+import {
+    GET_COMPANY_WEBHOOK,
+    GET_COMPANY_WEBHOOK_DESCRIPTION,
+    GET_MERCHANT_WEBHOOK,
+    GET_MERCHANT_WEBHOOK_DESCRIPTION,
+    LIST_ALL_COMPANY_WEBHOOKS,
+    LIST_ALL_COMPANY_WEBHOOKS_DESCRIPTION,
+    LIST_ALL_MERCHANT_WEBHOOKS,
+    LIST_ALL_MERCHANT_WEBHOOKS_DESCRIPTION,
+} from "./constants";
+
+const listAllMerchantWebhooksRequestObject = z.object(
+    {
+        merchantId: z.string(),
+        pageSize: z.number(),
+        pageNumber: z.number(),
+    }
+);
+
+const listAllMerchantWebhooks = async (
+    client: Client,
+    req: z.infer<
+        typeof listAllMerchantWebhooksRequestObject
+    >,
+) => {
+    const { merchantId, pageSize, pageNumber } = req;
+
+    const managementAPI = new ManagementAPI(client);
+    try {
+        return await managementAPI.WebhooksMerchantLevelApi.listAllWebhooks(
+            merchantId, pageNumber, pageSize
+        );
+    } catch (e) {
+        return "Failed to list all webhook configurations on merchant account. Error: " + JSON.stringify(e);
+    }
+};
+
+export const listAllMerchantWebhooksTool: Tool = {
+    name: LIST_ALL_MERCHANT_WEBHOOKS,
+    description: LIST_ALL_MERCHANT_WEBHOOKS_DESCRIPTION,
+    arguments: listAllMerchantWebhooksRequestObject,
+    invoke: listAllMerchantWebhooks,
+};
+
+const getMerchantWebhookShape: z.ZodRawShape = {
+    merchantId: z.string(),
+    webhookId: z.string(),
+};
+
+const getMerchantWebhookRequestObject = z.object(
+    getMerchantWebhookShape,
+);
+
+const getMerchantWebhook = async (
+    client: Client,
+    req: z.infer<
+        typeof getMerchantWebhookRequestObject
+    >,
+) => {
+    const { merchantId, webhookId } = req;
+
+    const managementAPI = new ManagementAPI(client);
+    try {
+        return await managementAPI.WebhooksMerchantLevelApi.getWebhook(
+            merchantId, webhookId
+        );
+    } catch (e) {
+        return "Failed to get merchant webhook configuration. Error: " + JSON.stringify(e);
+    }
+};
+
+export const getMerchantWebhookTool: Tool = {
+    name: GET_MERCHANT_WEBHOOK,
+    description: GET_MERCHANT_WEBHOOK_DESCRIPTION,
+    arguments: getMerchantWebhookRequestObject,
+    invoke: getMerchantWebhook,
+};
+
+const listAllCompanyWebhooksRequestObject = z.object(
+    {
+        companyId: z.string(),
+        pageSize: z.number(),
+        pageNumber: z.number(),
+    }
+);
+
+const listAllCompanyWebhooks = async (
+    client: Client,
+    req: z.infer<
+        typeof listAllCompanyWebhooksRequestObject
+    >,
+) => {
+    const { companyId, pageSize, pageNumber } = req;
+
+    const managementAPI = new ManagementAPI(client);
+    try {
+        return await managementAPI.WebhooksCompanyLevelApi.listAllWebhooks(
+            companyId, pageNumber, pageSize
+        );
+    } catch (e) {
+        return "Failed to list all webhook configurations on company account. Error: " + JSON.stringify(e);
+    }
+};
+
+export const listAllCompanyWebhooksTool: Tool = {
+    name: LIST_ALL_COMPANY_WEBHOOKS,
+    description: LIST_ALL_COMPANY_WEBHOOKS_DESCRIPTION,
+    arguments: listAllCompanyWebhooksRequestObject,
+    invoke: listAllCompanyWebhooks,
+};
+
+const getCompanyWebhookRequestObject = z.object(
+    {
+        companyId: z.string(),
+        webhookId: z.string(),
+    }
+);
+
+const getCompanyWebhook = async (
+    client: Client,
+    req: z.infer<
+        typeof getCompanyWebhookRequestObject
+    >,
+) => {
+    const { companyId, webhookId } = req;
+
+    const managementAPI = new ManagementAPI(client);
+    try {
+        return await managementAPI.WebhooksCompanyLevelApi.getWebhook(
+            companyId, webhookId
+        );
+    } catch (e) {
+        return "Failed to get company webhook configuration. Error: " + JSON.stringify(e);
+    }
+};
+
+export const getCompanyWebhookTool: Tool = {
+    name: GET_COMPANY_WEBHOOK,
+    description: GET_COMPANY_WEBHOOK_DESCRIPTION,
+    arguments: getCompanyWebhookRequestObject,
+    invoke: getCompanyWebhook,
+};


### PR DESCRIPTION
**Description**
This PR intends to add the webhook retrieval tools to the Adyen MCP server in order for an agent to retrieve and trouble shoot webhook configurations.

All tools are tested using Gemini CLI and the `modelcontextprotocol/inspector` package. 