### PR TITLE
Update mcp sdk and zod definition for schemas

### DIFF
--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -6,6 +6,7 @@ import { Client } from "@adyen/api-library";
 import { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
 import { tools } from "./tools/tools.js";
 import { Environment, getAdyenConfig } from "./configurations/configurations";
+import z from "zod";
 
 const APPLICATION_NAME = "adyen-mcp-server";
 const APP_NAME = "Adyen MCP";
@@ -33,11 +34,13 @@ async function main() {
   });
 
   for (const tool of tools) {
-    server.tool(
+    server.registerTool(
       tool.name,
-      tool.description,
-      tool.arguments.shape,
-      async (args: any, _extra: RequestHandlerExtra <any, any>) => {
+      {
+        description: tool.description,
+        inputSchema: tool.arguments.shape,
+      },
+      async (args: any, _extra: RequestHandlerExtra<any, any>) => {
         const result = await tool.invoke(adyenClient, args);
         return {
           content: [
@@ -50,6 +53,7 @@ async function main() {
       }
     );
   }
+  
   const transport = new StdioServerTransport();
   await server.connect(transport);
 }

--- a/typescript/src/tools/types.ts
+++ b/typescript/src/tools/types.ts
@@ -8,6 +8,6 @@ export interface Tool {
    */
   name: string;
   description: string;
-  arguments: z.ZodObject<any>;
+  arguments: z.ZodObject<z.ZodRawShape>;
   invoke: (adyenClient: Client, args: any) => Promise<any>;
 }


### PR DESCRIPTION
**Description**
Updates the tool builder to use the recommended `registerTool` method instead of the deprecated `tool` method.
Fixes the current failing build

**Tested scenarios**
Test pass, plus manual testing on copilot
