### PR TITLE
Add Management API -  GET tools to Adyen MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,16 @@ The [Adyen Model Context Protocol (MCP) server](https://docs.adyen.com/developme
    - List all webhooks - GET [`/merchants/{merchantId}/webhooks`](https://docs.adyen.com/api-explorer/Management/3/get/merchants/(merchantId)/webhooks)
    - Get a webhook - GET [`/companies/{companyId}/webhooks/{webhookId}`](https://docs.adyen.com/api-explorer/Management/3/get/companies/(companyId)/webhooks/(webhookId))
    - Get a webhook - GET [`/merchants/{merchantId}/webhooks/{webhookId}`](https://docs.adyen.com/api-explorer/Management/3/get/merchants/(merchantId)/webhooks/(webhookId))
-
+   - Test a webhook - POST [`/companies/{companyId}/webhooks/{webhookId}/test`](https://docs.adyen.com/api-explorer/Management/3/post/companies/(companyId)/webhooks/(webhookId)/test)
+   - Test a webhook - POST [`/merchants/{merchantId}/webhooks/{webhookId}/test`](https://docs.adyen.com/api-explorer/Management/3/post/merchants/(merchantId)/webhooks/(webhookId)/test)
+7. Management API - Payment methods
+   - Get all payment methods - GET [`/merchants/{merchantId}/paymentMethodSettings`](https://docs.adyen.com/api-explorer/Management/3/get/merchants/(merchantId)/paymentMethodSettings)
+   - Get payment method details - GET [`/merchants/{merchantId}/paymentMethodSettings/{paymentMethodId}`](https://docs.adyen.com/api-explorer/Management/3/get/merchants/(merchantId)/paymentMethodSettings/(paymentMethodId))
+8. Management API - Users
+    - Get a list of users - GET [`/companies/{companyId}/users`](https://docs.adyen.com/api-explorer/Management/3/get/companies/(companyId)/users)
+    - Get a list of users - GET [`/merchants/{merchantId}/users`](https://docs.adyen.com/api-explorer/Management/3/get/merchants/(merchantId)/users)
+    - Get user details - GET [`companies/{companyId}/users/{userId}`](https://docs.adyen.com/api-explorer/Management/3/get/companies/(companyId)/users/(userId))
+    - Get user details - GET [`merchants/{merchantId}/users/{userId}`](https://docs.adyen.com/api-explorer/Management/3/get/merchants/(merchantId)/users/(userId))
 
 ### Usage
 * Run the MCP server via `npx` with the following command:
@@ -79,6 +88,9 @@ Example usage in `.vscode`:
 * Management API — Terminal settings read
 * Management API — Terminal settings read and write
 * Management API — Webhooks read
+* Management API — Webhooks read and write
+* Management API — Payment methods read
+* Trigger webhook notifications
 
 Adyen recommends creating a new webservice user and generating a new API key for the purpose of this application.
 Only use the new user’s API key for the MCP application and limit the roles to match the tools you'll be using. 

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -28,11 +28,18 @@ The Adyen Model Context Protocol server allows you to integrate with Adyen APIs 
 6. Management API - Webhooks
    - List all webhooks
    - Get a webhook
-7. Configuration API - Account Holders
+   - Test a webhook
+7. Management API - Payment methods
+   - Get all payment methods
+   - Get payment method details
+8. Management API - Users
+    - Get a list of users
+    - Get user details
+9. Configuration API - Account Holders
    - Get account holder details and its capability settings.
-8. Legal entity management API - Legal entities and onboarding links
-   - Get legal entity details and its KYC information. 
-   - Create an onboarding link for a legal entity. 
+10. Legal entity management API - Legal entities and onboarding links
+    - Get legal entity details and its KYC information. 
+    - Create an onboarding link for a legal entity. 
 
 ### Usage
 To run to the MCP server via `npx` you can execute:
@@ -65,6 +72,9 @@ npx -y @adyen/mcp --adyenApiKey=YOUR_ADYEN_API_KEY --env=TEST --tools=list_all_c
 * Management API — Terminal settings read
 * Management API — Terminal settings read and write
 * Management API — Webhooks read
+* Management API — Webhooks read and write
+* Management API — Payment methods read
+* Trigger webhook notifications
 
 Adyen recommends creating a new webservice user and generating a new API key for the purpose of this application.
 Only use the new user’s API key for the MCP application and limit the roles to match the tools you'll be using. 

--- a/typescript/src/tools/management/paymentMethods/constants.ts
+++ b/typescript/src/tools/management/paymentMethods/constants.ts
@@ -1,0 +1,22 @@
+export const LIST_ALL_PAYMENT_METHODS_MERCHANT =
+  'list_all_payment_methods_merchant';
+export const LIST_ALL_PAYMENT_METHODS_MERCHANT_DESCRIPTION = `
+    Returns details for all payment methods of the merchant account identified in the path.
+
+    Args:
+        merchantId (string): 
+        pageSize (int, optional): The number of items to have on a page, maximum 100. The default is 10 items on a page.
+        pageNumber (int, optional): The number of the page to fetch.
+        businessLineId (string, optional): The unique identifier of the Business Line for which to return the payment methods.
+        storeId (string, optional): The unique identifier of the store for which to return the payment methods.
+   `;
+
+export const GET_PAYMENT_METHODS_DETAILS_MERCHANT =
+  'get_payment_methods_details_merchant';
+export const GET_PAYMENT_METHODS_DETAILS_MERCHANT_DESCRIPTION = `
+    Returns details for the merchant account and the payment method identified in the path.
+
+    Args:
+        merchantId (string): The unique identifier of the merchant account.
+        paymentMethodId (string): The unique identifier of the payment method.
+   `;

--- a/typescript/src/tools/management/paymentMethods/index.ts
+++ b/typescript/src/tools/management/paymentMethods/index.ts
@@ -1,0 +1,79 @@
+import { z } from 'zod';
+import { Client, ManagementAPI } from '@adyen/api-library';
+import { Tool } from '../../types.js';
+import {
+  GET_PAYMENT_METHODS_DETAILS_MERCHANT,
+  GET_PAYMENT_METHODS_DETAILS_MERCHANT_DESCRIPTION,
+  LIST_ALL_PAYMENT_METHODS_MERCHANT,
+  LIST_ALL_PAYMENT_METHODS_MERCHANT_DESCRIPTION,
+} from './constants.js';
+
+const listAllPaymentMethodsRequestObject = z.object({
+  merchantId: z.string(),
+  pageSize: z.number().optional(),
+  pageNumber: z.number().optional(),
+  businessLineId: z.string().optional(),
+  storeId: z.string().optional(),
+});
+
+const listAllPaymentMethods = async (
+  client: Client,
+  req: z.infer<typeof listAllPaymentMethodsRequestObject>,
+) => {
+  const { merchantId, pageSize, pageNumber, businessLineId, storeId } = req;
+
+  const managementAPI = new ManagementAPI(client);
+  try {
+    return await managementAPI.PaymentMethodsMerchantLevelApi.getAllPaymentMethods(
+      merchantId,
+      businessLineId,
+      storeId,
+      pageSize,
+      pageNumber,
+    );
+  } catch (e: unknown) {
+    return (
+      'Failed to list payment methods on merchant account. Error: ' +
+      (e instanceof Error ? e.message : 'Unknown error')
+    );
+  }
+};
+
+export const listAllPaymentMethodsMerchant: Tool = {
+  name: LIST_ALL_PAYMENT_METHODS_MERCHANT,
+  description: LIST_ALL_PAYMENT_METHODS_MERCHANT_DESCRIPTION,
+  arguments: listAllPaymentMethodsRequestObject,
+  invoke: listAllPaymentMethods,
+};
+
+const getPaymentMethodsRequestObject = z.object({
+  paymentMethodId: z.string(),
+  merchantId: z.string(),
+});
+
+const getPaymentMethodsDetails = async (
+  client: Client,
+  req: z.infer<typeof getPaymentMethodsRequestObject>,
+) => {
+  const { paymentMethodId, merchantId } = req;
+
+  const managementAPI = new ManagementAPI(client);
+  try {
+    return await managementAPI.PaymentMethodsMerchantLevelApi.getPaymentMethodDetails(
+      merchantId,
+      paymentMethodId,
+    );
+  } catch (e: unknown) {
+    return (
+      'Failed to list payment methods on merchant account. Error: ' +
+      (e instanceof Error ? e.message : 'Unknown error')
+    );
+  }
+};
+
+export const getPaymentMethodsDetailsMerchant: Tool = {
+  name: GET_PAYMENT_METHODS_DETAILS_MERCHANT,
+  description: GET_PAYMENT_METHODS_DETAILS_MERCHANT_DESCRIPTION,
+  arguments: getPaymentMethodsRequestObject,
+  invoke: getPaymentMethodsDetails,
+};

--- a/typescript/src/tools/management/users/index.ts
+++ b/typescript/src/tools/management/users/index.ts
@@ -1,0 +1,173 @@
+import { z } from 'zod';
+import { Client, ManagementAPI } from '@adyen/api-library';
+import { Tool } from '../../types.js';
+
+const listCompanyUsersRequestObject = z.object({
+  companyId: z
+    .string()
+    .describe('The unique identifier of the company account.'),
+  pageSize: z
+    .number()
+    .optional()
+    .describe(
+      'The number of items to have on a page. Maximum value is 100. The default is 10 items on a page.',
+    ),
+  pageNumber: z
+    .number()
+    .optional()
+    .describe('The number of the page to return.'),
+  userName: z
+    .string()
+    .optional()
+    .describe(
+      'The partial or complete username to select all users that match.',
+    ),
+});
+
+const listCompanyUsers = async (
+  client: Client,
+  req: z.infer<typeof listCompanyUsersRequestObject>,
+) => {
+  const { companyId, pageNumber, pageSize, userName } = req;
+
+  const managementAPI = new ManagementAPI(client);
+  try {
+    return await managementAPI.UsersCompanyLevelApi.listUsers(
+      companyId,
+      pageNumber,
+      pageSize,
+      userName,
+    );
+  } catch (e: unknown) {
+    return (
+      'Failed to list company users. Error: ' +
+      (e instanceof Error ? e.message : 'Unknown error')
+    );
+  }
+};
+
+export const listCompanyUsersTool: Tool = {
+  name: 'list_company_users',
+  description:
+    'Returns the list of users for the companyId identified in the path.',
+  arguments: listCompanyUsersRequestObject,
+  invoke: listCompanyUsers,
+};
+
+const getCompanyUserDetailsRequestObject = z.object({
+  companyId: z
+    .string()
+    .describe('The unique identifier of the company account.'),
+  userId: z.string().describe('The unique identifier of the user.'),
+});
+
+const getCompanyUserDetails = async (
+  client: Client,
+  req: z.infer<typeof getCompanyUserDetailsRequestObject>,
+) => {
+  const { companyId, userId } = req;
+
+  const managementAPI = new ManagementAPI(client);
+  try {
+    return await managementAPI.UsersCompanyLevelApi.getUserDetails(
+      companyId,
+      userId,
+    );
+  } catch (e: unknown) {
+    return (
+      'Failed to get company user details. Error: ' +
+      (e instanceof Error ? e.message : 'Unknown error')
+    );
+  }
+};
+
+export const getCompanyUserDetailsTool: Tool = {
+  name: 'get_company_user_details',
+  description:
+    'Returns user details for the userId and the companyId identified in the path.',
+  arguments: getCompanyUserDetailsRequestObject,
+  invoke: getCompanyUserDetails,
+};
+
+const listMerchantUsersRequestObject = z.object({
+  merchantId: z.string().describe('Unique identifier of the merchant.'),
+  pageSize: z
+    .number()
+    .optional()
+    .describe(
+      'The number of items to have on a page. Maximum value is 100. The default is 10 items on a page.',
+    ),
+  pageNumber: z
+    .number()
+    .optional()
+    .describe('The number of the page to return.'),
+  userName: z
+    .string()
+    .optional()
+    .describe(
+      'The partial or complete username to select all users that match.',
+    ),
+});
+
+const listMerchantUsers = async (
+  client: Client,
+  req: z.infer<typeof listMerchantUsersRequestObject>,
+) => {
+  const { merchantId, pageNumber, pageSize, userName } = req;
+
+  const managementAPI = new ManagementAPI(client);
+  try {
+    return await managementAPI.UsersMerchantLevelApi.listUsers(
+      merchantId,
+      pageNumber,
+      pageSize,
+      userName,
+    );
+  } catch (e: unknown) {
+    return (
+      'Failed to list merchant users. Error: ' +
+      (e instanceof Error ? e.message : 'Unknown error')
+    );
+  }
+};
+
+export const listMerchantUsersTool: Tool = {
+  name: 'list_merchant_users',
+  description:
+    'Returns a list of users associated with the merchantId specified in the path.',
+  arguments: listMerchantUsersRequestObject,
+  invoke: listMerchantUsers,
+};
+
+const getMerchantUserDetailsRequestObject = z.object({
+  merchantId: z.string().describe('Unique identifier of the merchant.'),
+  userId: z.string().describe('The unique identifier of the user.'),
+});
+
+const getMerchantUserDetails = async (
+  client: Client,
+  req: z.infer<typeof getMerchantUserDetailsRequestObject>,
+) => {
+  const { merchantId, userId } = req;
+
+  const managementAPI = new ManagementAPI(client);
+  try {
+    return await managementAPI.UsersMerchantLevelApi.getUserDetails(
+      merchantId,
+      userId,
+    );
+  } catch (e: unknown) {
+    return (
+      'Failed to get merchant user details. Error: ' +
+      (e instanceof Error ? e.message : 'Unknown error')
+    );
+  }
+};
+
+export const getMerchantUserDetailsTool: Tool = {
+  name: 'get_merchant_user_details',
+  description:
+    'Returns user details for the userId and the merchantId specified in the path.',
+  arguments: getMerchantUserDetailsRequestObject,
+  invoke: getMerchantUserDetails,
+};

--- a/typescript/src/tools/management/webhooks/constants.ts
+++ b/typescript/src/tools/management/webhooks/constants.ts
@@ -35,3 +35,24 @@ export const GET_COMPANY_WEBHOOK_DESCRIPTION = `
         companyID (string): Unique identifier of the company account.
         webhookId (string): Unique identifier of the webhook configuration.
    `;
+
+export const TEST_MERCHANT_WEBHOOK = 'test_merchant_webhook';
+export const TEST_MERCHANT_WEBHOOK_DESCRIPTION = `
+    Sends sample notifications to test if the webhook is set up correctly.
+
+    Args:
+        merchantId (string): The unique identifier of the merchant account.
+        webhookId (string): Unique identifier of the webhook configuration.
+        types (array[string]): List of event codes for which to send test notifications.
+   `;
+
+export const TEST_COMPANY_WEBHOOK = 'test_company_webhook';
+export const TEST_COMPANY_WEBHOOK_DESCRIPTION = `
+    Sends sample notifications to test if the webhook is set up correctly.
+
+    Args:
+        companyId (string): The unique identifier of the company account.
+        webhookId (string): Unique identifier of the webhook configuration.
+        types (array[string]): List of event codes for which to send test notifications.
+        merchantIds (array[string]): List of merchantId values for which test webhooks will be sent.
+   `;

--- a/typescript/src/tools/management/webhooks/index.ts
+++ b/typescript/src/tools/management/webhooks/index.ts
@@ -10,6 +10,10 @@ import {
   LIST_ALL_COMPANY_WEBHOOKS_DESCRIPTION,
   LIST_ALL_MERCHANT_WEBHOOKS,
   LIST_ALL_MERCHANT_WEBHOOKS_DESCRIPTION,
+  TEST_COMPANY_WEBHOOK,
+  TEST_COMPANY_WEBHOOK_DESCRIPTION,
+  TEST_MERCHANT_WEBHOOK,
+  TEST_MERCHANT_WEBHOOK_DESCRIPTION,
 } from './constants.js';
 
 const listAllMerchantWebhooksRequestObject = z.object({
@@ -144,4 +148,73 @@ export const getCompanyWebhookTool: Tool = {
   description: GET_COMPANY_WEBHOOK_DESCRIPTION,
   arguments: getCompanyWebhookRequestObject,
   invoke: getCompanyWebhook,
+};
+
+const testMerchantWebhookRequestObject = z.object({
+  merchantId: z.string(),
+  webhookId: z.string(),
+  types: z.array(z.string()),
+});
+
+const testMerchantWebhook = async (
+  client: Client,
+  req: z.infer<typeof testMerchantWebhookRequestObject>,
+) => {
+  const { merchantId, webhookId, types } = req;
+
+  const managementAPI = new ManagementAPI(client);
+  try {
+    return await managementAPI.WebhooksMerchantLevelApi.testWebhook(
+      merchantId,
+      webhookId,
+      { types: types },
+    );
+  } catch (e: unknown) {
+    return (
+      'Failed to test merchant webhook configuration. Error: ' +
+      (e instanceof Error ? e.message : 'Unknown error')
+    );
+  }
+};
+
+export const testMerchantWebhookTool: Tool = {
+  name: TEST_MERCHANT_WEBHOOK,
+  description: TEST_MERCHANT_WEBHOOK_DESCRIPTION,
+  arguments: testMerchantWebhookRequestObject,
+  invoke: testMerchantWebhook,
+};
+
+const testCompanyWebhookRequestObject = z.object({
+  companyId: z.string(),
+  webhookId: z.string(),
+  types: z.array(z.string()).optional(),
+  merchantIds: z.array(z.string()).optional(),
+});
+
+const testCompanyWebhook = async (
+  client: Client,
+  req: z.infer<typeof testCompanyWebhookRequestObject>,
+) => {
+  const { companyId, webhookId, types, merchantIds } = req;
+
+  const managementAPI = new ManagementAPI(client);
+  try {
+    return await managementAPI.WebhooksCompanyLevelApi.testWebhook(
+      companyId,
+      webhookId,
+      { types: types, merchantIds: merchantIds },
+    );
+  } catch (e: unknown) {
+    return (
+      'Failed to test company webhook configuration. Error: ' +
+      (e instanceof Error ? e.message : 'Unknown error')
+    );
+  }
+};
+
+export const testCompanyWebhookTool: Tool = {
+  name: TEST_COMPANY_WEBHOOK,
+  description: TEST_COMPANY_WEBHOOK_DESCRIPTION,
+  arguments: testCompanyWebhookRequestObject,
+  invoke: testCompanyWebhook,
 };

--- a/typescript/src/tools/tools.ts
+++ b/typescript/src/tools/tools.ts
@@ -25,9 +25,21 @@ import {
   getMerchantWebhookTool,
   listAllCompanyWebhooksTool,
   listAllMerchantWebhooksTool,
+  testCompanyWebhookTool,
+  testMerchantWebhookTool,
 } from './management/webhooks/index.js';
 import { AdyenConfig } from '../configurations/configurations';
 import { Tool } from './types';
+import {
+  getPaymentMethodsDetailsMerchant,
+  listAllPaymentMethodsMerchant,
+} from './management/paymentMethods/index.js';
+import {
+  getCompanyUserDetailsTool,
+  getMerchantUserDetailsTool,
+  listCompanyUsersTool,
+  listMerchantUsersTool,
+} from './management/users/index.js';
 
 export const tools: Tool[] = [
   createPaymentLinkTool,
@@ -46,8 +58,16 @@ export const tools: Tool[] = [
   getAccountHolderTool,
   listAllCompanyWebhooksTool,
   getCompanyWebhookTool,
+  testCompanyWebhookTool,
   listAllMerchantWebhooksTool,
   getMerchantWebhookTool,
+  testMerchantWebhookTool,
+  listCompanyUsersTool,
+  getCompanyUserDetailsTool,
+  listMerchantUsersTool,
+  getMerchantUserDetailsTool,
+  listAllPaymentMethodsMerchant,
+  getPaymentMethodsDetailsMerchant,
 ];
 
 const availableToolNames = tools.map((i) => `'${i.name}'`).join(', ');


### PR DESCRIPTION
**Description**
This PR adds Management API's payment method GET endpoints to the Adyen MCP server. Tested on Gemini CLI with flash model configured. 