### PR TITLE
Add company-level terminal ordering tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,22 @@ The [Adyen Model Context Protocol (MCP) server](https://docs.adyen.com/developme
 10. Management API - Allowed Origins
     - List all allowed origins - GET [`/companies/{companyId}/apiCredentials/{apiCredentialId}/allowedOrigins`](https://docs.adyen.com/api-explorer/Management/3/get/companies/(companyId)/apiCredentials/(apiCredentialId)/allowedOrigins)
     - List all allowed origins - GET [`/merchants/{merchantId}/apiCredentials/{apiCredentialId}/allowedOrigins`](https://docs.adyen.com/api-explorer/Management/3/get/merchants/(merchantId)/apiCredentials/(apiCredentialId)/allowedOrigins)
+11. Management API - Terminal Orders (company level)
+
+    These tools cover the full company-level terminal ordering flow. The typical sequence is: discover models → list orderable products for a country → resolve the billing entity → get or create a shipping location → place the order. Terminals are region-locked, so `/terminalProducts` requires a `country` and only returns what is orderable there. Billing entities are provisioned by Adyen during account onboarding and can only be listed (there is no create-billing-entity endpoint). Orders can only be updated or cancelled while their status is `Placed`. To make these requests, your API credential needs the **Management API — Terminal ordering read** and **Management API — Terminal ordering read and write** roles.
+
+    - `list_terminal_models` - Gets the terminal models the company can order - GET [`/companies/{companyId}/terminalModels`](https://docs.adyen.com/api-explorer/Management/3/get/companies/(companyId)/terminalModels)
+    - `list_terminal_products` - Gets orderable products for a country (and optional model) - GET [`/companies/{companyId}/terminalProducts`](https://docs.adyen.com/api-explorer/Management/3/get/companies/(companyId)/terminalProducts)
+    - `list_billing_entities` - Lists billing entities the order can be charged to - GET [`/companies/{companyId}/billingEntities`](https://docs.adyen.com/api-explorer/Management/3/get/companies/(companyId)/billingEntities)
+    - `list_shipping_locations` - Lists existing shipping locations - GET [`/companies/{companyId}/shippingLocations`](https://docs.adyen.com/api-explorer/Management/3/get/companies/(companyId)/shippingLocations)
+    - `create_shipping_location` - Creates a new shipping location - POST [`/companies/{companyId}/shippingLocations`](https://docs.adyen.com/api-explorer/Management/3/post/companies/(companyId)/shippingLocations)
+    - `create_terminal_order` - Places a terminal order - POST [`/companies/{companyId}/terminalOrders`](https://docs.adyen.com/api-explorer/Management/3/post/companies/(companyId)/terminalOrders)
+    - `list_terminal_orders` - Lists orders (filter by reference/status) - GET [`/companies/{companyId}/terminalOrders`](https://docs.adyen.com/api-explorer/Management/3/get/companies/(companyId)/terminalOrders)
+    - `get_terminal_order` - Gets a single order - GET [`/companies/{companyId}/terminalOrders/{orderId}`](https://docs.adyen.com/api-explorer/Management/3/get/companies/(companyId)/terminalOrders/(orderId))
+    - `update_terminal_order` - Updates a `Placed` order (items replace the whole array) - PATCH [`/companies/{companyId}/terminalOrders/{orderId}`](https://docs.adyen.com/api-explorer/Management/3/patch/companies/(companyId)/terminalOrders/(orderId))
+    - `cancel_terminal_order` - Cancels a `Placed` order - POST [`/companies/{companyId}/terminalOrders/{orderId}/cancel`](https://docs.adyen.com/api-explorer/Management/3/post/companies/(companyId)/terminalOrders/(orderId)/cancel)
+
+    All of these accept a company ID or a merchant ID (a merchant ID is auto-resolved to its company ID).
 
 ### Usage
 * Run the MCP server via `npx` with the following command:
@@ -97,6 +113,8 @@ Example usage in `.vscode`:
 * Management API — Webhooks read and write
 * Management API — Payment methods read
 * Management API — API credentials read
+* Management API — Terminal ordering read
+* Management API — Terminal ordering read and write
 * Trigger webhook notifications
 
 Adyen recommends creating a new webservice user and generating a new API key for the purpose of this application.

--- a/typescript/src/tools/management/terminalOrders/constants.ts
+++ b/typescript/src/tools/management/terminalOrders/constants.ts
@@ -1,0 +1,170 @@
+export const LIST_TERMINAL_MODELS_NAME = 'list_terminal_models';
+export const LIST_TERMINAL_MODELS_DESCRIPTION = `Gets a list of terminal models available for ordering.
+
+    Args:
+        companyId (string, required): The unique identifier of the company account.
+
+    Returns:
+        object: The Adyen API response listing terminal models.
+
+    Notes:
+        - Corresponds to the Adyen Management API GET /companies/{companyId}/terminalModels endpoint.`;
+
+export const LIST_TERMINAL_PRODUCTS_NAME = 'list_terminal_products';
+export const LIST_TERMINAL_PRODUCTS_DESCRIPTION = `Gets a list of terminal products available for ordering for a country.
+
+    Args:
+        companyId (string, required): The unique identifier of the company account.
+        country (string, required): Required. Two-letter ISO 3166-1 alpha-2 country code. Terminals are region-locked; the API returns only what is orderable for that country.
+        terminalModelId (string, optional): The unique identifier of the terminal model.
+        offset (integer, optional): The number of items to skip.
+        limit (integer, optional): The number of items to return.
+
+    Returns:
+        object: The Adyen API response listing terminal products.
+
+    Notes:
+        - Corresponds to the Adyen Management API GET /companies/{companyId}/terminalProducts endpoint.
+        - Part of the Terminal Ordering Workflow:
+          1. Call list_terminal_models to see available models.
+          2. Call list_terminal_products with the country code to get orderable product IDs.
+          3. Call list_billing_entities to get the billingEntityId.
+          4. Call list_shipping_locations or create_shipping_location to get a shippingLocationId.
+          5. Call create_terminal_order to place the order.`;
+
+export const LIST_BILLING_ENTITIES_NAME = 'list_billing_entities';
+export const LIST_BILLING_ENTITIES_DESCRIPTION = `Gets a list of billing entities for a company.
+
+    Args:
+        companyId (string, required): The unique identifier of the company account.
+        name (string, optional): The name of the billing entity to filter by.
+
+    Returns:
+        object: The Adyen API response listing billing entities.
+
+    Notes:
+        - Corresponds to the Adyen Management API GET /companies/{companyId}/billingEntities endpoint.
+        - NOTE: Billing entities are provisioned by Adyen during account onboarding and CANNOT be created via the API. If none is returned, it is an account-setup gap.`;
+
+export const LIST_SHIPPING_LOCATIONS_NAME = 'list_shipping_locations';
+export const LIST_SHIPPING_LOCATIONS_DESCRIPTION = `Gets a list of shipping locations for a company.
+
+    Args:
+        companyId (string, required): The unique identifier of the company account.
+        name (string, optional): The name of the shipping location to filter by.
+        offset (integer, optional): The number of items to skip.
+        limit (integer, optional): The number of items to return.
+
+    Returns:
+        object: The Adyen API response listing shipping locations.
+
+    Notes:
+        - Corresponds to the Adyen Management API GET /companies/{companyId}/shippingLocations endpoint.`;
+
+export const CREATE_SHIPPING_LOCATION_NAME = 'create_shipping_location';
+export const CREATE_SHIPPING_LOCATION_DESCRIPTION = `Creates a shipping location to use in terminal orders.
+
+    Args:
+        companyId (string, required): The unique identifier of the company account.
+        name (string, required): Name of the shipping location.
+        address (object, optional): Address object containing city, companyName, country, postalCode, stateOrProvince, streetAddress, streetAddress2.
+        contact (object, optional): Contact object containing email, firstName, infix, lastName, phoneNumber.
+
+    Returns:
+        object: The Adyen API response representing the created shipping location.
+
+    Notes:
+        - Corresponds to the Adyen Management API POST /companies/{companyId}/shippingLocations endpoint.
+        - After creating a shipping location, wait a few seconds before creating the order to ensure synchronization in the Adyen backend.`;
+
+export const CREATE_TERMINAL_ORDER_NAME = 'create_terminal_order';
+export const CREATE_TERMINAL_ORDER_DESCRIPTION = `Creates a terminal order.
+
+    Args:
+        companyId (string, required): The unique identifier of the company account.
+        items (array[object], required): List of order items, each containing:
+            - id (string, required): The unique product identifier from list_terminal_products.
+            - quantity (integer, required): Number of units to order.
+            - name (string, optional): Name of the product.
+            - installments (integer, optional): Number of installments.
+        billingEntityId (string, required): The unique identifier of the billing entity.
+        shippingLocationId (string, required): The unique identifier of the shipping location.
+        customerOrderReference (string, optional): Customer reference for the order.
+        taxId (string, optional): The tax ID of the order. Needed when shipping location and billing entity are in different countries.
+        orderType (string, optional): The order type.
+
+    Returns:
+        object: The Adyen API response representing the created terminal order.
+
+    Notes:
+        - Corresponds to the Adyen Management API POST /companies/{companyId}/terminalOrders endpoint.
+        - Terminal Ordering Workflow:
+          1. Use list_terminal_models to see available models.
+          2. Use list_terminal_products with a required two-letter ISO country code to get orderable product IDs for that country (terminals are region-locked; the API returns only what is orderable for that country).
+          3. Use list_billing_entities to get the billingEntityId (NOTE: billing entities are provisioned by Adyen from account onboarding and CANNOT be created via API; if none is returned, it's an account-setup gap).
+          4. Use list_shipping_locations or create_shipping_location to get a shippingLocationId. After creating a shipping location, wait a few seconds before creating the order.
+          5. Use create_terminal_order with items (array of {id, quantity}), billingEntityId, shippingLocationId, optional customerOrderReference and taxId.`;
+
+export const LIST_TERMINAL_ORDERS_NAME = 'list_terminal_orders';
+export const LIST_TERMINAL_ORDERS_DESCRIPTION = `Gets a list of terminal orders for a company.
+
+    Args:
+        companyId (string, required): The unique identifier of the company account.
+        customerOrderReference (string, optional): The customer order reference to filter by.
+        status (string, optional): The status of the terminal orders. Allowed values: Placed, Confirmed, Cancelled, Shipped, Delivered.
+        offset (integer, optional): The number of items to skip.
+        limit (integer, optional): The number of items to return.
+
+    Returns:
+        object: The Adyen API response listing terminal orders.
+
+    Notes:
+        - Corresponds to the Adyen Management API GET /companies/{companyId}/terminalOrders endpoint.`;
+
+export const GET_TERMINAL_ORDER_NAME = 'get_terminal_order';
+export const GET_TERMINAL_ORDER_DESCRIPTION = `Gets the status details of a terminal order by order ID.
+
+    Args:
+        companyId (string, required): The unique identifier of the company account.
+        orderId (string, required): The unique identifier of the terminal order.
+
+    Returns:
+        object: The Adyen API response representing the terminal order.
+
+    Notes:
+        - Corresponds to the Adyen Management API GET /companies/{companyId}/terminalOrders/{orderId} endpoint.`;
+
+export const UPDATE_TERMINAL_ORDER_NAME = 'update_terminal_order';
+export const UPDATE_TERMINAL_ORDER_DESCRIPTION = `Updates a terminal order.
+
+    Args:
+        companyId (string, required): The unique identifier of the company account.
+        orderId (string, required): The unique identifier of the terminal order.
+        items (array[object], optional): List of order items (updating items replaces the whole array).
+        billingEntityId (string, optional): The billing entity ID.
+        shippingLocationId (string, optional): The shipping location ID.
+        customerOrderReference (string, optional): The customer order reference.
+        taxId (string, optional): The tax ID.
+        orderType (string, optional): The order type.
+
+    Returns:
+        object: The Adyen API response representing the updated terminal order.
+
+    Notes:
+        - Corresponds to the Adyen Management API PATCH /companies/{companyId}/terminalOrders/{orderId} endpoint.
+        - Updates only work while the order status is "Placed".
+        - Updating items replaces the whole array.`;
+
+export const CANCEL_TERMINAL_ORDER_NAME = 'cancel_terminal_order';
+export const CANCEL_TERMINAL_ORDER_DESCRIPTION = `Cancels a terminal order.
+
+    Args:
+        companyId (string, required): The unique identifier of the company account.
+        orderId (string, required): The unique identifier of the terminal order.
+
+    Returns:
+        object: The Adyen API response representing the cancelled terminal order.
+
+    Notes:
+        - Corresponds to the Adyen Management API POST /companies/{companyId}/terminalOrders/{orderId}/cancel endpoint.
+        - Cancellations only work while the order status is "Placed".`;

--- a/typescript/src/tools/management/terminalOrders/index.ts
+++ b/typescript/src/tools/management/terminalOrders/index.ts
@@ -1,0 +1,308 @@
+import { z } from 'zod';
+import { ManagementAPI } from '@adyen/api-library';
+import { TerminalOrderRequest } from '@adyen/api-library/lib/src/typings/management/terminalOrderRequest.js';
+import { ShippingLocation } from '@adyen/api-library/lib/src/typings/management/shippingLocation.js';
+import { createTool } from '../terminals/toolFactory.js';
+import * as constants from './constants.js';
+import * as schemas from './schemas.js';
+
+// =================================================================
+//  Helper Functions
+// =================================================================
+
+/**
+ * Intelligently resolves a companyId. If the provided ID is a merchantId,
+ * it fetches the corresponding companyId. Otherwise, it returns the original ID.
+ */
+async function resolveCompanyId(
+  api: ManagementAPI,
+  id: string,
+): Promise<string> {
+  try {
+    const merchantAccount =
+      await api.AccountMerchantLevelApi.getMerchantAccount(id);
+    return merchantAccount?.companyId || id;
+  } catch (_e) {
+    return id;
+  }
+}
+
+// =================================================================
+//  Tool Definitions
+// =================================================================
+
+const listTerminalModelsTool = createTool({
+  name: constants.LIST_TERMINAL_MODELS_NAME,
+  description: constants.LIST_TERMINAL_MODELS_DESCRIPTION,
+  schema: {
+    companyId: z
+      .string()
+      .describe(
+        'The unique identifier of the company account (a merchant ID is also accepted and auto-resolved).',
+      ),
+  },
+  apiCall: async (api, args) => {
+    const companyId = await resolveCompanyId(api, args.companyId);
+    return api.TerminalOrdersCompanyLevelApi.listTerminalModels(companyId);
+  },
+});
+
+const listTerminalProductsTool = createTool({
+  name: constants.LIST_TERMINAL_PRODUCTS_NAME,
+  description: constants.LIST_TERMINAL_PRODUCTS_DESCRIPTION,
+  schema: {
+    companyId: z
+      .string()
+      .describe(
+        'The unique identifier of the company account (a merchant ID is also accepted and auto-resolved).',
+      ),
+    country: z
+      .string()
+      .describe(
+        'Required. Two-letter ISO 3166-1 alpha-2 country code. Terminals are region-locked.',
+      ),
+    terminalModelId: z
+      .string()
+      .optional()
+      .describe('The terminal model to filter products by.'),
+    offset: z
+      .number()
+      .int()
+      .optional()
+      .describe('The number of products to skip.'),
+    limit: z
+      .number()
+      .int()
+      .optional()
+      .describe('The number of products to return.'),
+  },
+  apiCall: async (api, args) => {
+    const companyId = await resolveCompanyId(api, args.companyId);
+    return api.TerminalOrdersCompanyLevelApi.listTerminalProducts(
+      companyId,
+      args.country,
+      args.terminalModelId,
+      args.offset,
+      args.limit,
+    );
+  },
+});
+
+const listBillingEntitiesTool = createTool({
+  name: constants.LIST_BILLING_ENTITIES_NAME,
+  description: constants.LIST_BILLING_ENTITIES_DESCRIPTION,
+  schema: {
+    companyId: z
+      .string()
+      .describe(
+        'The unique identifier of the company account (a merchant ID is also accepted and auto-resolved).',
+      ),
+    name: z
+      .string()
+      .optional()
+      .describe('The name of the billing entity to filter by.'),
+  },
+  apiCall: async (api, args) => {
+    const companyId = await resolveCompanyId(api, args.companyId);
+    return api.TerminalOrdersCompanyLevelApi.listBillingEntities(
+      companyId,
+      args.name,
+    );
+  },
+});
+
+const listShippingLocationsTool = createTool({
+  name: constants.LIST_SHIPPING_LOCATIONS_NAME,
+  description: constants.LIST_SHIPPING_LOCATIONS_DESCRIPTION,
+  schema: {
+    companyId: z
+      .string()
+      .describe(
+        'The unique identifier of the company account (a merchant ID is also accepted and auto-resolved).',
+      ),
+    name: z
+      .string()
+      .optional()
+      .describe('The name of the shipping location to filter by.'),
+    offset: z
+      .number()
+      .int()
+      .optional()
+      .describe('The number of locations to skip.'),
+    limit: z
+      .number()
+      .int()
+      .optional()
+      .describe('The number of locations to return.'),
+  },
+  apiCall: async (api, args) => {
+    const companyId = await resolveCompanyId(api, args.companyId);
+    return api.TerminalOrdersCompanyLevelApi.listShippingLocations(
+      companyId,
+      args.name,
+      args.offset,
+      args.limit,
+    );
+  },
+});
+
+const createShippingLocationTool = createTool({
+  name: constants.CREATE_SHIPPING_LOCATION_NAME,
+  description: constants.CREATE_SHIPPING_LOCATION_DESCRIPTION,
+  schema: {
+    companyId: z
+      .string()
+      .describe(
+        'The unique identifier of the company account (a merchant ID is also accepted and auto-resolved).',
+      ),
+    ...schemas.shippingLocationSchema.shape,
+  },
+  apiCall: async (api, args) => {
+    const companyId = await resolveCompanyId(api, args.companyId);
+    const { companyId: _companyId, ...shippingLocation } = args;
+    return api.TerminalOrdersCompanyLevelApi.createShippingLocation(
+      companyId,
+      shippingLocation as ShippingLocation,
+    );
+  },
+});
+
+const createTerminalOrderTool = createTool({
+  name: constants.CREATE_TERMINAL_ORDER_NAME,
+  description: constants.CREATE_TERMINAL_ORDER_DESCRIPTION,
+  schema: {
+    companyId: z
+      .string()
+      .describe(
+        'The unique identifier of the company account (a merchant ID is also accepted and auto-resolved).',
+      ),
+    ...schemas.terminalOrderRequestSchema.shape,
+  },
+  apiCall: async (api, args) => {
+    const companyId = await resolveCompanyId(api, args.companyId);
+    const { companyId: _companyId, ...terminalOrderRequest } = args;
+    return api.TerminalOrdersCompanyLevelApi.createOrder(
+      companyId,
+      terminalOrderRequest as TerminalOrderRequest,
+    );
+  },
+});
+
+const listTerminalOrdersTool = createTool({
+  name: constants.LIST_TERMINAL_ORDERS_NAME,
+  description: constants.LIST_TERMINAL_ORDERS_DESCRIPTION,
+  schema: {
+    companyId: z
+      .string()
+      .describe(
+        'The unique identifier of the company account (a merchant ID is also accepted and auto-resolved).',
+      ),
+    customerOrderReference: z
+      .string()
+      .optional()
+      .describe('Your reference for the order.'),
+    status: z
+      .enum(['Placed', 'Confirmed', 'Cancelled', 'Shipped', 'Delivered'])
+      .optional()
+      .describe('The status of the order(s) to filter by.'),
+    offset: z
+      .number()
+      .int()
+      .optional()
+      .describe('The number of orders to skip.'),
+    limit: z
+      .number()
+      .int()
+      .optional()
+      .describe('The number of orders to return.'),
+  },
+  apiCall: async (api, args) => {
+    const companyId = await resolveCompanyId(api, args.companyId);
+    return api.TerminalOrdersCompanyLevelApi.listOrders(
+      companyId,
+      args.customerOrderReference,
+      args.status,
+      args.offset,
+      args.limit,
+    );
+  },
+});
+
+const getTerminalOrderTool = createTool({
+  name: constants.GET_TERMINAL_ORDER_NAME,
+  description: constants.GET_TERMINAL_ORDER_DESCRIPTION,
+  schema: {
+    companyId: z
+      .string()
+      .describe(
+        'The unique identifier of the company account (a merchant ID is also accepted and auto-resolved).',
+      ),
+    orderId: z
+      .string()
+      .describe('The unique identifier of the terminal order.'),
+  },
+  apiCall: async (api, args) => {
+    const companyId = await resolveCompanyId(api, args.companyId);
+    return api.TerminalOrdersCompanyLevelApi.getOrder(companyId, args.orderId);
+  },
+});
+
+const updateTerminalOrderTool = createTool({
+  name: constants.UPDATE_TERMINAL_ORDER_NAME,
+  description: constants.UPDATE_TERMINAL_ORDER_DESCRIPTION,
+  schema: {
+    companyId: z
+      .string()
+      .describe(
+        'The unique identifier of the company account (a merchant ID is also accepted and auto-resolved).',
+      ),
+    orderId: z
+      .string()
+      .describe('The unique identifier of the terminal order.'),
+    ...schemas.terminalOrderRequestSchema.partial().shape,
+  },
+  apiCall: async (api, args) => {
+    const companyId = await resolveCompanyId(api, args.companyId);
+    const { companyId: _companyId, orderId, ...terminalOrderRequest } = args;
+    return api.TerminalOrdersCompanyLevelApi.updateOrder(
+      companyId,
+      orderId,
+      terminalOrderRequest as TerminalOrderRequest,
+    );
+  },
+});
+
+const cancelTerminalOrderTool = createTool({
+  name: constants.CANCEL_TERMINAL_ORDER_NAME,
+  description: constants.CANCEL_TERMINAL_ORDER_DESCRIPTION,
+  schema: {
+    companyId: z
+      .string()
+      .describe(
+        'The unique identifier of the company account (a merchant ID is also accepted and auto-resolved).',
+      ),
+    orderId: z
+      .string()
+      .describe('The unique identifier of the terminal order.'),
+  },
+  apiCall: async (api, args) => {
+    const companyId = await resolveCompanyId(api, args.companyId);
+    return api.TerminalOrdersCompanyLevelApi.cancelOrder(
+      companyId,
+      args.orderId,
+    );
+  },
+});
+
+export const terminalOrderTools = [
+  listTerminalModelsTool,
+  listTerminalProductsTool,
+  listBillingEntitiesTool,
+  listShippingLocationsTool,
+  createShippingLocationTool,
+  createTerminalOrderTool,
+  listTerminalOrdersTool,
+  getTerminalOrderTool,
+  updateTerminalOrderTool,
+  cancelTerminalOrderTool,
+];

--- a/typescript/src/tools/management/terminalOrders/schemas.ts
+++ b/typescript/src/tools/management/terminalOrders/schemas.ts
@@ -1,0 +1,134 @@
+import { z } from 'zod';
+
+// Validation rules below mirror the Adyen Management API v3 definition
+// (https://docs.adyen.com/api-explorer/Management/3/). The API itself often
+// returns vague errors, so we validate the documented field formats up front
+// and return precise messages the caller can act on.
+
+export const addressSchema = z.object({
+  city: z.string().optional().describe('The name of the city.'),
+  companyName: z.string().optional().describe('The name of the company.'),
+  country: z
+    .string()
+    .regex(
+      /^[A-Za-z]{2}$/,
+      'country must be a two-letter ISO 3166-1 alpha-2 code, for example "DE", "NL" or "US".',
+    )
+    .transform((c) => c.toUpperCase())
+    .optional()
+    .describe(
+      'The two-letter ISO 3166-1 alpha-2 country code (e.g. DE, NL, US). Automatically upper-cased.',
+    ),
+  postalCode: z.string().optional().describe('The postal code.'),
+  stateOrProvince: z
+    .string()
+    .optional()
+    .describe(
+      'The state or province as an ISO 3166-2 code (e.g. "ON" for Ontario). Only applicable for Australia, Brazil, Canada, India, Mexico, New Zealand and the United States.',
+    ),
+  streetAddress: z
+    .string()
+    .optional()
+    .describe('The name of the street, and the house or building number.'),
+  streetAddress2: z
+    .string()
+    .optional()
+    .describe('Additional address details, if any.'),
+});
+
+export const contactSchema = z.object({
+  email: z
+    .string()
+    .email(
+      'email must be a valid email address, for example "name@example.com".',
+    )
+    .optional()
+    .describe("The individual's email address."),
+  firstName: z.string().optional().describe("The individual's first name."),
+  infix: z
+    .string()
+    .optional()
+    .describe("The infix in the individual's name, if any."),
+  lastName: z.string().optional().describe("The individual's last name."),
+  phoneNumber: z
+    .string()
+    .regex(
+      /^\+?[0-9]{10,14}$/,
+      'phoneNumber must be 10-14 digits with an optional leading "+", for example "+491234567890".',
+    )
+    .optional()
+    .describe(
+      "The individual's phone number, specified as 10-14 digits with an optional + prefix.",
+    ),
+});
+
+export const orderItemSchema = z.object({
+  id: z
+    .string()
+    .min(
+      1,
+      'id is required: use a product id returned by list_terminal_products.',
+    )
+    .describe('The unique product identifier from list_terminal_products.'),
+  quantity: z
+    .number()
+    .int('quantity must be a whole number.')
+    .positive('quantity must be at least 1.')
+    .describe('Number of units to order (at least 1).'),
+  name: z.string().optional().describe('The name of the product.'),
+  installments: z
+    .number()
+    .int('installments must be a whole number.')
+    .positive('installments must be at least 1.')
+    .optional()
+    .describe('The number of installments for the specified product id.'),
+});
+
+export const shippingLocationSchema = z.object({
+  name: z
+    .string()
+    .min(1, 'name is required: a unique name for the shipping location.')
+    .describe(
+      'The unique name of the shipping location (used to identify it later).',
+    ),
+  contact: contactSchema
+    .optional()
+    .describe('The contact details of the recipient.'),
+  address: addressSchema
+    .optional()
+    .describe(
+      'The shipping address. Provide at least country, streetAddress, city and postalCode for a deliverable location.',
+    ),
+});
+
+export const terminalOrderRequestSchema = z.object({
+  items: z
+    .array(orderItemSchema)
+    .min(1, 'items must contain at least one product to order.')
+    .describe('The products included in the order (at least one).'),
+  billingEntityId: z
+    .string()
+    .min(1, 'billingEntityId, if provided, must not be empty.')
+    .optional()
+    .describe(
+      'The id of the billing entity to use for the order (from list_billing_entities). Required for all countries except Brazil.',
+    ),
+  shippingLocationId: z
+    .string()
+    .min(
+      1,
+      'shippingLocationId is required: use an id from list_shipping_locations or create_shipping_location.',
+    )
+    .describe(
+      'The id of the shipping location to use for the order (from list_shipping_locations or create_shipping_location).',
+    ),
+  customerOrderReference: z
+    .string()
+    .optional()
+    .describe('The merchant-defined purchase order reference.'),
+  taxId: z
+    .string()
+    .optional()
+    .describe('The tax number of the billing entity.'),
+  orderType: z.string().optional().describe('Type of order.'),
+});

--- a/typescript/src/tools/tools.ts
+++ b/typescript/src/tools/tools.ts
@@ -17,6 +17,7 @@ import {
   listMerchantAccountsTool,
 } from './management/accounts/index.js';
 import { terminalTools } from './management/terminals/index.js';
+import { terminalOrderTools } from './management/terminalOrders/index.js';
 import { createHostedOnboardingLinkTool } from './legalEntityManagement/onboardingLinks/index.js';
 import { getLegalEntityTool } from './legalEntityManagement/legalEntities/index.js';
 import { getAccountHolderTool } from './configuration/accountHolders/index.js';
@@ -61,6 +62,7 @@ export const tools: Tool[] = [
   getMerchantAccountsTool,
   cancelPaymentTool,
   ...terminalTools,
+  ...terminalOrderTools,
   createHostedOnboardingLinkTool,
   getLegalEntityTool,
   getAccountHolderTool,

--- a/typescript/test/terminalOrders.test.ts
+++ b/typescript/test/terminalOrders.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Client, ManagementAPI } from '@adyen/api-library';
+import { tools } from '../src/tools/tools.js';
+
+vi.mock('@adyen/api-library');
+
+const TERMINAL_ORDER_TOOL_NAMES = [
+  'list_terminal_models',
+  'list_terminal_products',
+  'list_billing_entities',
+  'list_shipping_locations',
+  'create_shipping_location',
+  'create_terminal_order',
+  'list_terminal_orders',
+  'get_terminal_order',
+  'update_terminal_order',
+  'cancel_terminal_order',
+];
+
+const findTool = (name: string) => {
+  const tool = tools.find((t) => t.name === name);
+  if (!tool) throw new Error(`Tool not found: ${name}`);
+  return tool;
+};
+
+describe('terminalOrders', () => {
+  describe('registration', () => {
+    it('registers all ten terminal-ordering tools', () => {
+      const names = tools.map((t) => t.name);
+      for (const name of TERMINAL_ORDER_TOOL_NAMES) {
+        expect(names).toContain(name);
+      }
+    });
+
+    it('exposes a description and a zod argument schema for each tool', () => {
+      for (const name of TERMINAL_ORDER_TOOL_NAMES) {
+        const tool = findTool(name);
+        expect(tool.description).toBeTruthy();
+        expect(tool.arguments).toBeDefined();
+        expect(typeof tool.invoke).toBe('function');
+      }
+    });
+  });
+
+  describe('input validation (mirrors the Adyen Management API definition)', () => {
+    it('requires companyId on every tool', () => {
+      for (const name of TERMINAL_ORDER_TOOL_NAMES) {
+        const result = findTool(name).arguments.safeParse({});
+        expect(result.success).toBe(false);
+      }
+    });
+
+    it('rejects a country that is not a two-letter ISO code', () => {
+      const result = findTool('create_shipping_location').arguments.safeParse({
+        companyId: 'C1',
+        name: 'Berlin HQ',
+        address: { country: 'Germany' },
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].path).toContain('country');
+      }
+    });
+
+    it('normalizes a valid country code to upper case', () => {
+      const result = findTool('create_shipping_location').arguments.safeParse({
+        companyId: 'C1',
+        name: 'Berlin HQ',
+        address: { country: 'de' },
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.address?.country).toBe('DE');
+      }
+    });
+
+    it('rejects an invalid phone number format', () => {
+      const result = findTool('create_shipping_location').arguments.safeParse({
+        companyId: 'C1',
+        name: 'Berlin HQ',
+        contact: { phoneNumber: '12-34' },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('accepts a phone number with an optional leading plus', () => {
+      const result = findTool('create_shipping_location').arguments.safeParse({
+        companyId: 'C1',
+        name: 'Berlin HQ',
+        contact: { phoneNumber: '+491234567890' },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects an invalid email address', () => {
+      const result = findTool('create_shipping_location').arguments.safeParse({
+        companyId: 'C1',
+        name: 'Berlin HQ',
+        contact: { email: 'not-an-email' },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('requires at least one item on a terminal order', () => {
+      const result = findTool('create_terminal_order').arguments.safeParse({
+        companyId: 'C1',
+        items: [],
+        billingEntityId: 'BE1',
+        shippingLocationId: 'SL1',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects a non-positive item quantity', () => {
+      const result = findTool('create_terminal_order').arguments.safeParse({
+        companyId: 'C1',
+        items: [{ id: 'P1', quantity: 0 }],
+        billingEntityId: 'BE1',
+        shippingLocationId: 'SL1',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('requires billingEntityId and shippingLocationId on a terminal order', () => {
+      const result = findTool('create_terminal_order').arguments.safeParse({
+        companyId: 'C1',
+        items: [{ id: 'P1', quantity: 1 }],
+        billingEntityId: '',
+        shippingLocationId: '',
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const paths = result.error.issues.map((i) => i.path.join('.'));
+        expect(paths).toContain('billingEntityId');
+        expect(paths).toContain('shippingLocationId');
+      }
+    });
+
+    it('accepts a fully valid terminal order request', () => {
+      const result = findTool('create_terminal_order').arguments.safeParse({
+        companyId: 'C1',
+        items: [{ id: 'P1', quantity: 2 }],
+        billingEntityId: 'BE1',
+        shippingLocationId: 'SL1',
+        customerOrderReference: 'PO-123',
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('invocation against the Management API', () => {
+    const mockClient = {} as Client;
+    let mockListModels: ReturnType<typeof vi.fn>;
+    let mockCreateOrder: ReturnType<typeof vi.fn>;
+    let mockGetMerchantAccount: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      mockListModels = vi.fn();
+      mockCreateOrder = vi.fn();
+      // resolveCompanyId calls getMerchantAccount; rejecting makes it fall back
+      // to the provided id (i.e. treat the argument as a company id directly).
+      mockGetMerchantAccount = vi
+        .fn()
+        .mockRejectedValue(new Error('not a merchant'));
+      vi.mocked(ManagementAPI).mockImplementation(function () {
+        return {
+          AccountMerchantLevelApi: {
+            getMerchantAccount: mockGetMerchantAccount,
+          },
+          TerminalOrdersCompanyLevelApi: {
+            listTerminalModels: mockListModels,
+            createOrder: mockCreateOrder,
+          },
+        } as any;
+      });
+    });
+
+    it('passes the resolved companyId through to the Management API', async () => {
+      mockListModels.mockResolvedValue({ data: [] });
+      const result = await findTool('list_terminal_models').invoke(mockClient, {
+        companyId: 'CompanyAccount',
+      });
+      expect(mockListModels).toHaveBeenCalledWith('CompanyAccount');
+      expect(result).toEqual({ data: [] });
+    });
+
+    it('returns a friendly error string instead of throwing on API failure', async () => {
+      mockCreateOrder.mockRejectedValue(
+        new Error('HTTP Exception: 422. Unprocessable Entity'),
+      );
+      const result = await findTool('create_terminal_order').invoke(
+        mockClient,
+        {
+          companyId: 'C1',
+          items: [{ id: 'P1', quantity: 1 }],
+          billingEntityId: 'BE1',
+          shippingLocationId: 'SL1',
+        },
+      );
+      expect(typeof result).toBe('string');
+      expect(result).toContain('Failed to execute tool');
+      expect(result).toContain('422');
+    });
+  });
+});


### PR DESCRIPTION
## What
Adds 10 Management API tools covering the full company-level terminal
ordering flow: list_terminal_models, list_terminal_products,
list_billing_entities, list_shipping_locations,
create_shipping_location, create_terminal_order, list_terminal_orders,
get_terminal_order, update_terminal_order, cancel_terminal_order.

## Approach
- companyId args also accept a merchantId, auto-resolved via
  AccountMerchantLevelApi.getMerchantAccount, since callers often only
  have the merchant ID on hand.
- zod schemas validate country codes, phone numbers, email and
  required order fields up front with actionable error messages,
  since the Management API's own validation errors are often vague.
- billingEntityId is optional in the schema (required by the API for
  every country except Brazil, per Adyen docs).
- Follows the existing createTool factory / error-sanitization pattern
  used by the terminals/ tools.

## Tests
- typescript/test/terminalOrders.test.ts: tool registration and zod
  input validation (required fields, country code normalization,
  phone number format).
- `npm run lint` and `npm run test` pass locally.

## Docs
README updated with the new tool list and the two required API
credential roles (Terminal ordering read / read and write).