### PR TITLE
IAM-5802 Introduce Management API update user tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ The [Adyen Model Context Protocol (MCP) server](https://docs.adyen.com/developme
    - Get a list of users - GET [`/merchants/{merchantId}/users`](https://docs.adyen.com/api-explorer/Management/3/get/merchants/(merchantId)/users)
    - Get user details - GET [`companies/{companyId}/users/{userId}`](https://docs.adyen.com/api-explorer/Management/3/get/companies/(companyId)/users/(userId))
    - Get user details - GET [`merchants/{merchantId}/users/{userId}`](https://docs.adyen.com/api-explorer/Management/3/get/merchants/(merchantId)/users/(userId))
+   - Update a user - PATCH [`/companies/{companyId}/users/{userId}`](https://docs.adyen.com/api-explorer/Management/3/patch/companies/(companyId)/users/(userId)). The user is identified by `userId`, `email`, or `username` (the id is resolved internally); supports activate/deactivate, adding or removing roles without overwriting, and setting associated merchant accounts.
+   - Update a user - PATCH [`/merchants/{merchantId}/users/{userId}`](https://docs.adyen.com/api-explorer/Management/3/patch/merchants/(merchantId)/users/(userId)). The user is identified by `userId`, `email`, or `username` (the id is resolved internally); supports activate/deactivate and adding, removing, or replacing roles.
+
+   The update tools resolve the user from `email`/`username` via the list endpoint and make no change when the identifier matches zero or multiple users. Bulk changes (for example deactivating many users, or assigning a role to a list of users) are performed by calling the tool once per user. These tools work in both `TEST` and `LIVE`; for `LIVE` you must pass `--env=LIVE --livePrefix=YOUR_PREFIX_URL`. Treat bulk deactivation and role removal as high-impact operations. The webservice user needs `Management API — Users read` (for resolution) and `Management API — Users read and write` (for the update); grant the minimum roles required for your use case.
 9. Management API - API Credentials
    - List all API Credentials - GET [`/companies/{companyId}/apiCredentials`](https://docs.adyen.com/api-explorer/Management/3/get/companies/(companyId)/apiCredentials)
    - List all API Credentials - GET [`/merchants/{merchantId}/apiCredentials`](https://docs.adyen.com/api-explorer/Management/3/get/merchants/(merchantId)/apiCredentials)
@@ -97,6 +101,8 @@ Example usage in `.vscode`:
 * Management API — Webhooks read and write
 * Management API — Payment methods read
 * Management API — API credentials read
+* Management API — Users read
+* Management API — Users read and write
 * Trigger webhook notifications
 
 Adyen recommends creating a new webservice user and generating a new API key for the purpose of this application.

--- a/typescript/src/tools/management/users/constants.ts
+++ b/typescript/src/tools/management/users/constants.ts
@@ -1,0 +1,23 @@
+export const LIST_COMPANY_USERS_NAME = 'list_company_users';
+export const LIST_COMPANY_USERS_DESCRIPTION =
+  'Returns the list of users for the companyId identified in the path.';
+
+export const GET_COMPANY_USER_DETAILS_NAME = 'get_company_user_details';
+export const GET_COMPANY_USER_DETAILS_DESCRIPTION =
+  'Returns user details for the userId and the companyId identified in the path.';
+
+export const LIST_MERCHANT_USERS_NAME = 'list_merchant_users';
+export const LIST_MERCHANT_USERS_DESCRIPTION =
+  'Returns a list of users associated with the merchantId specified in the path.';
+
+export const GET_MERCHANT_USER_DETAILS_NAME = 'get_merchant_user_details';
+export const GET_MERCHANT_USER_DETAILS_DESCRIPTION =
+  'Returns user details for the userId and the merchantId specified in the path.';
+
+export const UPDATE_COMPANY_USER_NAME = 'update_company_user';
+export const UPDATE_COMPANY_USER_DESCRIPTION =
+  'Updates a company-level user identified by userId, email, or username (resolved to a single user internally). Can activate/deactivate, add or remove roles without overwriting, replace roles, and set associated merchant accounts. Returns an actionable error and makes no change when the identifier matches zero or multiple users. Bulk changes are done by calling this once per user.';
+
+export const UPDATE_MERCHANT_USER_NAME = 'update_merchant_user';
+export const UPDATE_MERCHANT_USER_DESCRIPTION =
+  'Updates a merchant-level user identified by userId, email, or username (resolved to a single user internally). Can activate/deactivate and add, remove, or replace roles. Returns an actionable error and makes no change when the identifier matches zero or multiple users. Bulk changes are done by calling this once per user.';

--- a/typescript/src/tools/management/users/index.ts
+++ b/typescript/src/tools/management/users/index.ts
@@ -1,6 +1,20 @@
 import { z } from 'zod';
-import { Client, ManagementAPI } from '@adyen/api-library';
+import { Client, ManagementAPI, Types } from '@adyen/api-library';
 import { Tool } from '../../types.js';
+import {
+  LIST_COMPANY_USERS_NAME,
+  LIST_COMPANY_USERS_DESCRIPTION,
+  GET_COMPANY_USER_DETAILS_NAME,
+  GET_COMPANY_USER_DETAILS_DESCRIPTION,
+  LIST_MERCHANT_USERS_NAME,
+  LIST_MERCHANT_USERS_DESCRIPTION,
+  GET_MERCHANT_USER_DETAILS_NAME,
+  GET_MERCHANT_USER_DETAILS_DESCRIPTION,
+  UPDATE_COMPANY_USER_NAME,
+  UPDATE_COMPANY_USER_DESCRIPTION,
+  UPDATE_MERCHANT_USER_NAME,
+  UPDATE_MERCHANT_USER_DESCRIPTION,
+} from './constants.js';
 
 const listCompanyUsersRequestObject = z.object({
   companyId: z
@@ -47,9 +61,8 @@ const listCompanyUsers = async (
 };
 
 export const listCompanyUsersTool: Tool = {
-  name: 'list_company_users',
-  description:
-    'Returns the list of users for the companyId identified in the path.',
+  name: LIST_COMPANY_USERS_NAME,
+  description: LIST_COMPANY_USERS_DESCRIPTION,
   arguments: listCompanyUsersRequestObject,
   invoke: listCompanyUsers,
 };
@@ -82,9 +95,8 @@ const getCompanyUserDetails = async (
 };
 
 export const getCompanyUserDetailsTool: Tool = {
-  name: 'get_company_user_details',
-  description:
-    'Returns user details for the userId and the companyId identified in the path.',
+  name: GET_COMPANY_USER_DETAILS_NAME,
+  description: GET_COMPANY_USER_DETAILS_DESCRIPTION,
   arguments: getCompanyUserDetailsRequestObject,
   invoke: getCompanyUserDetails,
 };
@@ -132,9 +144,8 @@ const listMerchantUsers = async (
 };
 
 export const listMerchantUsersTool: Tool = {
-  name: 'list_merchant_users',
-  description:
-    'Returns a list of users associated with the merchantId specified in the path.',
+  name: LIST_MERCHANT_USERS_NAME,
+  description: LIST_MERCHANT_USERS_DESCRIPTION,
   arguments: listMerchantUsersRequestObject,
   invoke: listMerchantUsers,
 };
@@ -165,9 +176,300 @@ const getMerchantUserDetails = async (
 };
 
 export const getMerchantUserDetailsTool: Tool = {
-  name: 'get_merchant_user_details',
-  description:
-    'Returns user details for the userId and the merchantId specified in the path.',
+  name: GET_MERCHANT_USER_DETAILS_NAME,
+  description: GET_MERCHANT_USER_DETAILS_DESCRIPTION,
   arguments: getMerchantUserDetailsRequestObject,
   invoke: getMerchantUserDetails,
+};
+
+type ResolvableUser = {
+  id: string;
+  email: string;
+  username: string;
+  roles: Array<string>;
+};
+
+type UserResolution = { user: ResolvableUser } | { error: string };
+
+const resolveUser = async <T extends ResolvableUser>(
+  listPage: (
+    pageNumber: number,
+    pageSize: number,
+    userName?: string,
+  ) => Promise<{ data?: Array<T>; pagesTotal?: number }>,
+  identifier: { email?: string; username?: string },
+): Promise<UserResolution> => {
+  const term = identifier.username ?? identifier.email ?? '';
+  const pageSize = 100;
+  const matches = new Map<string, T>();
+
+  let pageNumber = 1;
+  let pagesTotal = 1;
+  do {
+    const response = await listPage(pageNumber, pageSize, term);
+    for (const user of response.data ?? []) {
+      const matchesUsername =
+        identifier.username !== undefined &&
+        user.username?.toLowerCase() === identifier.username.toLowerCase();
+      const matchesEmail =
+        identifier.email !== undefined &&
+        user.email?.toLowerCase() === identifier.email.toLowerCase();
+      if (matchesUsername || matchesEmail) {
+        matches.set(user.id, user);
+      }
+    }
+    pagesTotal = response.pagesTotal ?? 1;
+    pageNumber += 1;
+  } while (pageNumber <= pagesTotal);
+
+  const found = Array.from(matches.values());
+  if (found.length === 0) {
+    return { error: `No user found matching "${term}". No update performed.` };
+  }
+  if (found.length > 1) {
+    return {
+      error: `Found ${found.length} users matching "${term}". Provide a more specific identifier. No update performed.`,
+    };
+  }
+  return { user: found[0] };
+};
+
+const applyRoleDelta = (
+  currentRoles: Array<string>,
+  opts: {
+    roles?: Array<string>;
+    addRoles?: Array<string>;
+    removeRoles?: Array<string>;
+  },
+): Array<string> | undefined => {
+  if (
+    opts.roles === undefined &&
+    opts.addRoles === undefined &&
+    opts.removeRoles === undefined
+  ) {
+    return undefined;
+  }
+  const next = new Set(opts.roles ?? currentRoles ?? []);
+  (opts.addRoles ?? []).forEach((role) => next.add(role));
+  (opts.removeRoles ?? []).forEach((role) => next.delete(role));
+  return Array.from(next);
+};
+
+const userIdentifierFields = {
+  userId: z
+    .string()
+    .optional()
+    .describe(
+      'The unique identifier of the user. If omitted, provide email or username to resolve the user.',
+    ),
+  email: z
+    .string()
+    .optional()
+    .describe(
+      'The email address of the user, used to resolve the user when userId is not provided.',
+    ),
+  username: z
+    .string()
+    .optional()
+    .describe(
+      'The username of the user, used to resolve the user when userId is not provided.',
+    ),
+  active: z
+    .boolean()
+    .optional()
+    .describe(
+      'Set to false to deactivate the user, or true to reactivate the user.',
+    ),
+  roles: z
+    .array(z.string())
+    .optional()
+    .describe(
+      'The complete list of roles for this user. This replaces all existing roles. Prefer addRoles/removeRoles to change roles without overwriting.',
+    ),
+  addRoles: z
+    .array(z.string())
+    .optional()
+    .describe('Roles to add to the user without removing existing roles.'),
+  removeRoles: z
+    .array(z.string())
+    .optional()
+    .describe('Roles to remove from the user, keeping the remaining roles.'),
+};
+
+const updateCompanyUserRequestObject = z.object({
+  companyId: z
+    .string()
+    .describe('The unique identifier of the company account.'),
+  ...userIdentifierFields,
+  associatedMerchantAccounts: z
+    .array(z.string())
+    .optional()
+    .describe('The list of merchant accounts to associate the user with.'),
+});
+
+const updateCompanyUser = async (
+  client: Client,
+  req: z.infer<typeof updateCompanyUserRequestObject>,
+) => {
+  const {
+    companyId,
+    userId,
+    email,
+    username,
+    active,
+    roles,
+    addRoles,
+    removeRoles,
+    associatedMerchantAccounts,
+  } = req;
+
+  if (!userId && !email && !username) {
+    return 'Failed to update company user. Error: provide one of userId, email, or username to identify the user.';
+  }
+
+  const managementAPI = new ManagementAPI(client);
+  try {
+    const needsCurrentRoles =
+      addRoles !== undefined || removeRoles !== undefined;
+    let resolvedUserId = userId;
+    let currentRoles: Array<string> = [];
+
+    if (!resolvedUserId) {
+      const resolution = await resolveUser(
+        (pageNumber, pageSize, userName) =>
+          managementAPI.UsersCompanyLevelApi.listUsers(
+            companyId,
+            pageNumber,
+            pageSize,
+            userName,
+          ),
+        { email, username },
+      );
+      if ('error' in resolution) {
+        return 'Failed to update company user. Error: ' + resolution.error;
+      }
+      resolvedUserId = resolution.user.id;
+      currentRoles = resolution.user.roles ?? [];
+    } else if (needsCurrentRoles) {
+      const user = await managementAPI.UsersCompanyLevelApi.getUserDetails(
+        companyId,
+        resolvedUserId,
+      );
+      currentRoles = user.roles ?? [];
+    }
+
+    const request: Types.management.UpdateCompanyUserRequest = {};
+    if (active !== undefined) request.active = active;
+    if (associatedMerchantAccounts !== undefined) {
+      request.associatedMerchantAccounts = associatedMerchantAccounts;
+    }
+    const nextRoles = applyRoleDelta(currentRoles, {
+      roles,
+      addRoles,
+      removeRoles,
+    });
+    if (nextRoles !== undefined) request.roles = nextRoles;
+
+    return await managementAPI.UsersCompanyLevelApi.updateUserDetails(
+      companyId,
+      resolvedUserId,
+      request,
+    );
+  } catch (e: unknown) {
+    return (
+      'Failed to update company user. Error: ' +
+      (e instanceof Error ? e.message : 'Unknown error')
+    );
+  }
+};
+
+export const updateCompanyUserTool: Tool = {
+  name: UPDATE_COMPANY_USER_NAME,
+  description: UPDATE_COMPANY_USER_DESCRIPTION,
+  arguments: updateCompanyUserRequestObject,
+  invoke: updateCompanyUser,
+};
+
+const updateMerchantUserRequestObject = z.object({
+  merchantId: z.string().describe('Unique identifier of the merchant.'),
+  ...userIdentifierFields,
+});
+
+const updateMerchantUser = async (
+  client: Client,
+  req: z.infer<typeof updateMerchantUserRequestObject>,
+) => {
+  const {
+    merchantId,
+    userId,
+    email,
+    username,
+    active,
+    roles,
+    addRoles,
+    removeRoles,
+  } = req;
+
+  if (!userId && !email && !username) {
+    return 'Failed to update merchant user. Error: provide one of userId, email, or username to identify the user.';
+  }
+
+  const managementAPI = new ManagementAPI(client);
+  try {
+    const needsCurrentRoles =
+      addRoles !== undefined || removeRoles !== undefined;
+    let resolvedUserId = userId;
+    let currentRoles: Array<string> = [];
+
+    if (!resolvedUserId) {
+      const resolution = await resolveUser(
+        (pageNumber, pageSize, userName) =>
+          managementAPI.UsersMerchantLevelApi.listUsers(
+            merchantId,
+            pageNumber,
+            pageSize,
+            userName,
+          ),
+        { email, username },
+      );
+      if ('error' in resolution) {
+        return 'Failed to update merchant user. Error: ' + resolution.error;
+      }
+      resolvedUserId = resolution.user.id;
+      currentRoles = resolution.user.roles ?? [];
+    } else if (needsCurrentRoles) {
+      const user = await managementAPI.UsersMerchantLevelApi.getUserDetails(
+        merchantId,
+        resolvedUserId,
+      );
+      currentRoles = user.roles ?? [];
+    }
+
+    const request: Types.management.UpdateMerchantUserRequest = {};
+    if (active !== undefined) request.active = active;
+    const nextRoles = applyRoleDelta(currentRoles, {
+      roles,
+      addRoles,
+      removeRoles,
+    });
+    if (nextRoles !== undefined) request.roles = nextRoles;
+
+    return await managementAPI.UsersMerchantLevelApi.updateUser(
+      merchantId,
+      resolvedUserId,
+      request,
+    );
+  } catch (e: unknown) {
+    return (
+      'Failed to update merchant user. Error: ' +
+      (e instanceof Error ? e.message : 'Unknown error')
+    );
+  }
+};
+
+export const updateMerchantUserTool: Tool = {
+  name: UPDATE_MERCHANT_USER_NAME,
+  description: UPDATE_MERCHANT_USER_DESCRIPTION,
+  arguments: updateMerchantUserRequestObject,
+  invoke: updateMerchantUser,
 };

--- a/typescript/src/tools/tools.ts
+++ b/typescript/src/tools/tools.ts
@@ -39,6 +39,8 @@ import {
   getMerchantUserDetailsTool,
   listCompanyUsersTool,
   listMerchantUsersTool,
+  updateCompanyUserTool,
+  updateMerchantUserTool,
 } from './management/users/index.js';
 import {
   listAllCompanyApiCredentialsTool,
@@ -74,6 +76,8 @@ export const tools: Tool[] = [
   getCompanyUserDetailsTool,
   listMerchantUsersTool,
   getMerchantUserDetailsTool,
+  updateCompanyUserTool,
+  updateMerchantUserTool,
   listAllPaymentMethodsMerchant,
   getPaymentMethodsDetailsMerchant,
   listAllCompanyApiCredentialsTool,

--- a/typescript/test/tools.test.ts
+++ b/typescript/test/tools.test.ts
@@ -51,6 +51,20 @@ describe('tools', () => {
         expect(names).toContain('create_payment_links');
         expect(names).toContain('get_merchant_account');
       });
+
+      it('should expose the user update tools', () => {
+        const userUpdateToolNames = [
+          'update_company_user',
+          'update_merchant_user',
+        ];
+        const config = createConfig({ tools: userUpdateToolNames });
+        const result = getActiveTools(config);
+
+        expect(result.size).toBe(userUpdateToolNames.length);
+
+        const names = Array.from(result).map((t) => t.name);
+        userUpdateToolNames.forEach((name) => expect(names).toContain(name));
+      });
     });
 
     describe('combined filtering & deduplication', () => {

--- a/typescript/test/users.test.ts
+++ b/typescript/test/users.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Client, ManagementAPI } from '@adyen/api-library';
+
+vi.mock('@adyen/api-library');
+
+const mockClient = {} as Client;
+
+describe('user update tools', () => {
+  let tools: typeof import('../src/tools/management/users/index.js');
+
+  let companyListUsers: ReturnType<typeof vi.fn>;
+  let companyGetUserDetails: ReturnType<typeof vi.fn>;
+  let companyUpdateUserDetails: ReturnType<typeof vi.fn>;
+  let merchantListUsers: ReturnType<typeof vi.fn>;
+  let merchantGetUserDetails: ReturnType<typeof vi.fn>;
+  let merchantUpdateUser: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    companyListUsers = vi.fn();
+    companyGetUserDetails = vi.fn();
+    companyUpdateUserDetails = vi.fn();
+    merchantListUsers = vi.fn();
+    merchantGetUserDetails = vi.fn();
+    merchantUpdateUser = vi.fn();
+
+    vi.mocked(ManagementAPI).mockImplementation(function () {
+      return {
+        UsersCompanyLevelApi: {
+          listUsers: companyListUsers,
+          getUserDetails: companyGetUserDetails,
+          updateUserDetails: companyUpdateUserDetails,
+        },
+        UsersMerchantLevelApi: {
+          listUsers: merchantListUsers,
+          getUserDetails: merchantGetUserDetails,
+          updateUser: merchantUpdateUser,
+        },
+      } as any;
+    });
+
+    tools = await import('../src/tools/management/users/index.js');
+  });
+
+  describe('update_company_user', () => {
+    it('resolves the user by email and issues the update', async () => {
+      companyListUsers.mockResolvedValue({
+        data: [
+          {
+            id: 'U1',
+            email: 'alice@example.com',
+            username: 'alice',
+            roles: ['A'],
+          },
+        ],
+        pagesTotal: 1,
+      });
+      companyUpdateUserDetails.mockResolvedValue({ id: 'U1' });
+
+      const result = await tools.updateCompanyUserTool.invoke(mockClient, {
+        companyId: 'C1',
+        email: 'alice@example.com',
+        active: false,
+      });
+
+      expect(companyListUsers).toHaveBeenCalledWith(
+        'C1',
+        1,
+        100,
+        'alice@example.com',
+      );
+      expect(companyUpdateUserDetails).toHaveBeenCalledWith('C1', 'U1', {
+        active: false,
+      });
+      expect(result).toEqual({ id: 'U1' });
+    });
+
+    it('merges addRoles/removeRoles onto the resolved roles without clobbering', async () => {
+      companyListUsers.mockResolvedValue({
+        data: [
+          {
+            id: 'U1',
+            email: 'alice@example.com',
+            username: 'alice',
+            roles: ['Merchant admin', 'Legacy'],
+          },
+        ],
+        pagesTotal: 1,
+      });
+      companyUpdateUserDetails.mockResolvedValue({ id: 'U1' });
+
+      await tools.updateCompanyUserTool.invoke(mockClient, {
+        companyId: 'C1',
+        username: 'alice',
+        addRoles: ['Reports'],
+        removeRoles: ['Legacy'],
+      });
+
+      const [, , body] = companyUpdateUserDetails.mock.calls[0];
+      expect(new Set(body.roles)).toEqual(
+        new Set(['Merchant admin', 'Reports']),
+      );
+    });
+
+    it('returns an error and performs no update when no user matches', async () => {
+      companyListUsers.mockResolvedValue({ data: [], pagesTotal: 1 });
+
+      const result = await tools.updateCompanyUserTool.invoke(mockClient, {
+        companyId: 'C1',
+        email: 'missing@example.com',
+        active: false,
+      });
+
+      expect(result).toContain('No user found');
+      expect(companyUpdateUserDetails).not.toHaveBeenCalled();
+    });
+
+    it('returns an error and performs no update when multiple users match', async () => {
+      companyListUsers.mockResolvedValue({
+        data: [
+          { id: 'U1', email: 'dup@example.com', username: 'a', roles: [] },
+          { id: 'U2', email: 'dup@example.com', username: 'b', roles: [] },
+        ],
+        pagesTotal: 1,
+      });
+
+      const result = await tools.updateCompanyUserTool.invoke(mockClient, {
+        companyId: 'C1',
+        email: 'dup@example.com',
+        active: false,
+      });
+
+      expect(result).toContain('Found 2 users');
+      expect(companyUpdateUserDetails).not.toHaveBeenCalled();
+    });
+
+    it('uses userId directly without listing, fetching current roles for a delta', async () => {
+      companyGetUserDetails.mockResolvedValue({ id: 'U9', roles: ['A'] });
+      companyUpdateUserDetails.mockResolvedValue({ id: 'U9' });
+
+      await tools.updateCompanyUserTool.invoke(mockClient, {
+        companyId: 'C1',
+        userId: 'U9',
+        addRoles: ['B'],
+      });
+
+      expect(companyListUsers).not.toHaveBeenCalled();
+      expect(companyGetUserDetails).toHaveBeenCalledWith('C1', 'U9');
+      const [, , body] = companyUpdateUserDetails.mock.calls[0];
+      expect(new Set(body.roles)).toEqual(new Set(['A', 'B']));
+    });
+
+    it('requires an identifier', async () => {
+      const result = await tools.updateCompanyUserTool.invoke(mockClient, {
+        companyId: 'C1',
+        active: false,
+      });
+
+      expect(result).toContain('provide one of userId, email, or username');
+      expect(companyListUsers).not.toHaveBeenCalled();
+      expect(companyUpdateUserDetails).not.toHaveBeenCalled();
+    });
+
+    it('returns a sanitized error string when the update call fails', async () => {
+      companyListUsers.mockResolvedValue({
+        data: [
+          {
+            id: 'U1',
+            email: 'alice@example.com',
+            username: 'alice',
+            roles: [],
+          },
+        ],
+        pagesTotal: 1,
+      });
+      companyUpdateUserDetails.mockRejectedValue(
+        new Error('HTTP Exception: 403'),
+      );
+
+      const result = await tools.updateCompanyUserTool.invoke(mockClient, {
+        companyId: 'C1',
+        email: 'alice@example.com',
+        active: false,
+      });
+
+      expect(result).toBe(
+        'Failed to update company user. Error: HTTP Exception: 403',
+      );
+    });
+  });
+
+  describe('update_merchant_user', () => {
+    it('resolves the user by email and issues the update', async () => {
+      merchantListUsers.mockResolvedValue({
+        data: [
+          { id: 'M1', email: 'bob@example.com', username: 'bob', roles: [] },
+        ],
+        pagesTotal: 1,
+      });
+      merchantUpdateUser.mockResolvedValue({ id: 'M1' });
+
+      const result = await tools.updateMerchantUserTool.invoke(mockClient, {
+        merchantId: 'MERCH',
+        email: 'bob@example.com',
+        active: true,
+      });
+
+      expect(merchantListUsers).toHaveBeenCalledWith(
+        'MERCH',
+        1,
+        100,
+        'bob@example.com',
+      );
+      expect(merchantUpdateUser).toHaveBeenCalledWith('MERCH', 'M1', {
+        active: true,
+      });
+      expect(result).toEqual({ id: 'M1' });
+    });
+
+    it('returns an error and performs no update when no user matches', async () => {
+      merchantListUsers.mockResolvedValue({ data: [], pagesTotal: 1 });
+
+      const result = await tools.updateMerchantUserTool.invoke(mockClient, {
+        merchantId: 'MERCH',
+        username: 'ghost',
+        roles: ['A'],
+      });
+
+      expect(result).toContain('No user found');
+      expect(merchantUpdateUser).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
**Description**
Extended Management API User scope operations: created tools to update company/merchant user with a different status, set of roles, an set of Merchant accounts

**Tested scenarios**
1. A support engineer/developer/merchant that has access to Management API and configured the Adyen-MCP is interacting with an AI agent. They ask agent to activate/deactivate a set of users (providing their emails/usernames/userIds).
2. A support engineer/developer/merchant that has access to Management API and configured the Adyen-MCP is interacting with an AI agent. They ask agent to add/revoke a specified role (providing the Role name) to/from a set of users (providing their emails/usernames/userIds).
3. A support engineer/developer/merchant that has access to Management API and configured the Adyen-MCP is interacting with an AI agent. They ask agent to add/revoke access to a specified Merchant account (providing the account code) to/from a set of users (providing their emails/usernames/userIds).
