### PR TITLE
Introduce tool annotations as well as helpers to identify read-only versus write tools

### DIFF
--- a/typescript/README.md
+++ b/typescript/README.md
@@ -63,6 +63,8 @@ We advise to only run a subset of tools required for your particular use case:
 npx -y @adyen/mcp --adyenApiKey=YOUR_ADYEN_API_KEY --env=TEST --tools=list_all_company_webhooks,list_all_merchant_webhooks
 ```
 
+Tools include MCP annotations that identify read-only and destructive operations. Clients can use these hints to request confirmation before invoking write tools.
+
 **Note:** To run certain functionality (tools) in the mcp-server, you need a webservice user with the following roles: 
 * Management API - Accounts Read
 * Management API - Payment methods Read

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -40,6 +40,7 @@ async function main() {
       tool.name,
       {
         description: tool.description,
+        annotations: tool.annotations,
         inputSchema: tool.arguments.shape,
       },
       async (args: any, _extra: RequestHandlerExtra<any, any>) => {

--- a/typescript/src/tools/annotations.ts
+++ b/typescript/src/tools/annotations.ts
@@ -10,11 +10,11 @@ export const readOnly = (title: string): ToolAnnotations => ({
 
 export const writes = (
   title: string,
-  destructive: boolean,
+  options: { destructive: boolean; idempotent?: boolean },
 ): ToolAnnotations => ({
   title,
   readOnlyHint: false,
-  destructiveHint: destructive,
-  idempotentHint: false,
+  destructiveHint: options.destructive,
+  idempotentHint: options.idempotent ?? false,
   openWorldHint: true,
 });

--- a/typescript/src/tools/annotations.ts
+++ b/typescript/src/tools/annotations.ts
@@ -1,0 +1,20 @@
+import { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+
+export const readOnly = (title: string): ToolAnnotations => ({
+  title,
+  readOnlyHint: true,
+  destructiveHint: false,
+  idempotentHint: true,
+  openWorldHint: true,
+});
+
+export const writes = (
+  title: string,
+  destructive: boolean,
+): ToolAnnotations => ({
+  title,
+  readOnlyHint: false,
+  destructiveHint: destructive,
+  idempotentHint: false,
+  openWorldHint: true,
+});

--- a/typescript/src/tools/checkout/modifications/index.ts
+++ b/typescript/src/tools/checkout/modifications/index.ts
@@ -82,7 +82,7 @@ const cancelPayment = async (
 
 export const refundPaymentTool: Tool = {
   name: REFUND_PAYMENT_NAME,
-  annotations: writes('Refund payment', true),
+  annotations: writes('Refund payment', { destructive: true }),
   description: REFUND_PAYMENT_DESCRIPTION,
   arguments: refundPaymentObject,
   invoke: refundPayment,
@@ -90,7 +90,7 @@ export const refundPaymentTool: Tool = {
 
 export const cancelPaymentTool: Tool = {
   name: CANCEL_PAYMENT_NAME,
-  annotations: writes('Cancel payment', true),
+  annotations: writes('Cancel payment', { destructive: true }),
   description: CANCEL_PAYMENT_DESCRIPTION,
   arguments: cancelPaymentObject,
   invoke: cancelPayment,

--- a/typescript/src/tools/checkout/modifications/index.ts
+++ b/typescript/src/tools/checkout/modifications/index.ts
@@ -7,6 +7,7 @@ import {
   REFUND_PAYMENT_NAME,
 } from './constants.js';
 import { Tool } from '../../types.js';
+import { writes } from '../../annotations.js';
 
 const refundPaymentRequestShape: z.ZodRawShape = {
   pspReference: z.string(),
@@ -81,6 +82,7 @@ const cancelPayment = async (
 
 export const refundPaymentTool: Tool = {
   name: REFUND_PAYMENT_NAME,
+  annotations: writes('Refund payment', true),
   description: REFUND_PAYMENT_DESCRIPTION,
   arguments: refundPaymentObject,
   invoke: refundPayment,
@@ -88,6 +90,7 @@ export const refundPaymentTool: Tool = {
 
 export const cancelPaymentTool: Tool = {
   name: CANCEL_PAYMENT_NAME,
+  annotations: writes('Cancel payment', true),
   description: CANCEL_PAYMENT_DESCRIPTION,
   arguments: cancelPaymentObject,
   invoke: cancelPayment,

--- a/typescript/src/tools/checkout/paymentLinks/index.ts
+++ b/typescript/src/tools/checkout/paymentLinks/index.ts
@@ -101,7 +101,7 @@ const updatePaymentLink = async (
 
 export const createPaymentLinkTool: Tool = {
   name: CREATE_PAYMENT_LINKS_NAME,
-  annotations: writes('Create payment link', false),
+  annotations: writes('Create payment link', { destructive: false }),
   description: CREATE_PAYMENT_LINKS_DESCRIPTION,
   arguments: createPaymentLinkObject,
   invoke: createPaymentLink,
@@ -117,7 +117,10 @@ export const getPaymentLinkTool: Tool = {
 
 export const updatePaymentLinkTool: Tool = {
   name: UPDATE_PAYMENT_LINK_NAME,
-  annotations: writes('Update payment link', true),
+  annotations: writes('Update payment link', {
+    destructive: true,
+    idempotent: true,
+  }),
   description: UPDATE_PAYMENT_LINK_DESCRIPTION,
   arguments: updatePaymentLinkObject,
   invoke: updatePaymentLink,

--- a/typescript/src/tools/checkout/paymentLinks/index.ts
+++ b/typescript/src/tools/checkout/paymentLinks/index.ts
@@ -9,6 +9,7 @@ import {
   UPDATE_PAYMENT_LINK_NAME,
 } from './constants.js';
 import { Tool } from '../../types.js';
+import { readOnly, writes } from '../../annotations.js';
 
 const createPaymentLinkRequestShape: z.ZodRawShape = {
   currency: z.string(),
@@ -100,6 +101,7 @@ const updatePaymentLink = async (
 
 export const createPaymentLinkTool: Tool = {
   name: CREATE_PAYMENT_LINKS_NAME,
+  annotations: writes('Create payment link', false),
   description: CREATE_PAYMENT_LINKS_DESCRIPTION,
   arguments: createPaymentLinkObject,
   invoke: createPaymentLink,
@@ -107,6 +109,7 @@ export const createPaymentLinkTool: Tool = {
 
 export const getPaymentLinkTool: Tool = {
   name: GET_PAYMENT_LINK_NAME,
+  annotations: readOnly('Get payment link'),
   description: GET_PAYMENT_LINK_DESCRIPTION,
   arguments: getPaymentLinkObject,
   invoke: getPaymentLink,
@@ -114,6 +117,7 @@ export const getPaymentLinkTool: Tool = {
 
 export const updatePaymentLinkTool: Tool = {
   name: UPDATE_PAYMENT_LINK_NAME,
+  annotations: writes('Update payment link', true),
   description: UPDATE_PAYMENT_LINK_DESCRIPTION,
   arguments: updatePaymentLinkObject,
   invoke: updatePaymentLink,

--- a/typescript/src/tools/checkout/payments/index.ts
+++ b/typescript/src/tools/checkout/payments/index.ts
@@ -9,6 +9,7 @@ import {
   GET_PAYMENT_SESSION_NAME,
 } from './constants.js';
 import { Tool } from '../../types.js';
+import { readOnly, writes } from '../../annotations.js';
 
 const paymentSessionRequestShape: z.ZodRawShape = {
   currency: z.string(),
@@ -105,6 +106,7 @@ const getPaymentMethods = async (
 
 export const createPaymentSessionTool: Tool = {
   name: CREATE_PAYMENT_SESSION_NAME,
+  annotations: writes('Create payment session', false),
   description: CREATE_PAYMENT_SESSION_DESCRIPTION,
   arguments: paymentSessionObject,
   invoke: createPaymentSession,
@@ -112,6 +114,7 @@ export const createPaymentSessionTool: Tool = {
 
 export const getPaymentSessionTool: Tool = {
   name: GET_PAYMENT_SESSION_NAME,
+  annotations: readOnly('Get payment session'),
   description: GET_PAYMENT_SESSION_DESCRIPTION,
   arguments: getPaymentSessionObject,
   invoke: getPaymentSession,
@@ -119,6 +122,7 @@ export const getPaymentSessionTool: Tool = {
 
 export const getPaymentMethodsTool: Tool = {
   name: GET_PAYMENT_METHODS_NAME,
+  annotations: readOnly('Get payment methods'),
   description: GET_PAYMENT_METHODS_DESCRIPTION,
   arguments: getPaymentMethodsObject,
   invoke: getPaymentMethods,

--- a/typescript/src/tools/checkout/payments/index.ts
+++ b/typescript/src/tools/checkout/payments/index.ts
@@ -106,7 +106,7 @@ const getPaymentMethods = async (
 
 export const createPaymentSessionTool: Tool = {
   name: CREATE_PAYMENT_SESSION_NAME,
-  annotations: writes('Create payment session', false),
+  annotations: writes('Create payment session', { destructive: false }),
   description: CREATE_PAYMENT_SESSION_DESCRIPTION,
   arguments: paymentSessionObject,
   invoke: createPaymentSession,

--- a/typescript/src/tools/configuration/accountHolders/index.ts
+++ b/typescript/src/tools/configuration/accountHolders/index.ts
@@ -5,6 +5,7 @@ import {
   GET_ACCOUNT_HOLDER_DESCRIPTION,
 } from './constants.js';
 import { Tool } from '../../types.js';
+import { readOnly } from '../../annotations.js';
 
 const getAccountHolderRequestShape: z.ZodRawShape = {
   id: z.string(),
@@ -30,6 +31,7 @@ const getAccountHolder = async (
 
 export const getAccountHolderTool: Tool = {
   name: GET_ACCOUNT_HOLDER_NAME,
+  annotations: readOnly('Get account holder'),
   description: GET_ACCOUNT_HOLDER_DESCRIPTION,
   arguments: getAccountHolderObject,
   invoke: getAccountHolder,

--- a/typescript/src/tools/legalEntityManagement/legalEntities/index.ts
+++ b/typescript/src/tools/legalEntityManagement/legalEntities/index.ts
@@ -5,6 +5,7 @@ import {
   GET_LEGAL_ENTITY_DESCRIPTION,
 } from './constants.js';
 import { Tool } from '../../types.js';
+import { readOnly } from '../../annotations.js';
 
 const getLegalEntityRequestShape: z.ZodRawShape = {
   id: z.string(),
@@ -30,6 +31,7 @@ const getLegalEntity = async (
 
 export const getLegalEntityTool: Tool = {
   name: GET_LEGAL_ENTITY_NAME,
+  annotations: readOnly('Get legal entity'),
   description: GET_LEGAL_ENTITY_DESCRIPTION,
   arguments: getLegalEntityObject,
   invoke: getLegalEntity,

--- a/typescript/src/tools/legalEntityManagement/onboardingLinks/index.ts
+++ b/typescript/src/tools/legalEntityManagement/onboardingLinks/index.ts
@@ -5,6 +5,7 @@ import {
   CREATE_HOSTED_ONBOARDING_LINK_NAME,
 } from './constants.js';
 import { Tool } from '../../types.js';
+import { writes } from '../../annotations.js';
 
 const createHostedOnboardingLinkShape: z.ZodRawShape = {
   id: z.string(),
@@ -37,6 +38,7 @@ const createHostedOnboardingLink = async (
 
 export const createHostedOnboardingLinkTool: Tool = {
   name: CREATE_HOSTED_ONBOARDING_LINK_NAME,
+  annotations: writes('Create hosted onboarding link', false),
   description: CREATE_HOSTED_ONBOARDING_LINK_DESCRIPTION,
   arguments: createHostedOnboardingLinkObject,
   invoke: createHostedOnboardingLink,

--- a/typescript/src/tools/legalEntityManagement/onboardingLinks/index.ts
+++ b/typescript/src/tools/legalEntityManagement/onboardingLinks/index.ts
@@ -38,7 +38,7 @@ const createHostedOnboardingLink = async (
 
 export const createHostedOnboardingLinkTool: Tool = {
   name: CREATE_HOSTED_ONBOARDING_LINK_NAME,
-  annotations: writes('Create hosted onboarding link', false),
+  annotations: writes('Create hosted onboarding link', { destructive: false }),
   description: CREATE_HOSTED_ONBOARDING_LINK_DESCRIPTION,
   arguments: createHostedOnboardingLinkObject,
   invoke: createHostedOnboardingLink,

--- a/typescript/src/tools/management/accounts/index.ts
+++ b/typescript/src/tools/management/accounts/index.ts
@@ -7,6 +7,7 @@ import {
   LIST_MERCHANT_ACCOUNTS_NAME,
 } from './constants.js';
 import { Tool } from '../../types.js';
+import { readOnly } from '../../annotations.js';
 
 const listMerchantAccountsRequestShape: z.ZodRawShape = {
   pageSize: z.number(),
@@ -41,6 +42,7 @@ const listMerchantAccounts = async (
 
 export const listMerchantAccountsTool: Tool = {
   name: LIST_MERCHANT_ACCOUNTS_NAME,
+  annotations: readOnly('List merchant accounts'),
   description: LIST_MERCHANT_ACCOUNTS_DESCRIPTION,
   arguments: listMerchantAccountsRequestObject,
   invoke: listMerchantAccounts,
@@ -75,6 +77,7 @@ const getMerchantAccount = async (
 
 export const getMerchantAccountsTool: Tool = {
   name: GET_MERCHANT_ACCOUNTS_NAME,
+  annotations: readOnly('Get merchant account'),
   description: GET_MERCHANT_ACCOUNTS_DESCRIPTION,
   arguments: getMerchantAccountRequestObject,
   invoke: getMerchantAccount,

--- a/typescript/src/tools/management/allowedOrigins/index.ts
+++ b/typescript/src/tools/management/allowedOrigins/index.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { Client, ManagementAPI } from '@adyen/api-library';
 import { Tool } from '../../types.js';
+import { readOnly } from '../../annotations.js';
 
 const listAllMerchantAllowedOriginsRequestObject = z.object({
   merchantId: z
@@ -34,6 +35,7 @@ const listAllMerchantAllowedOrigins = async (
 
 export const listAllMerchantAllowedOriginsTool: Tool = {
   name: 'list_all_merchant_allowed_origins',
+  annotations: readOnly('List merchant allowed origins'),
   description:
     'Returns the list of allowed origins for the API credential identified in the path.',
   arguments: listAllMerchantAllowedOriginsRequestObject,
@@ -72,6 +74,7 @@ const listAllCompanyAllowedOrigins = async (
 
 export const listAllCompanyAllowedOriginsTool: Tool = {
   name: 'list_all_company_allowed_origins',
+  annotations: readOnly('List company allowed origins'),
   description:
     'Returns the list of allowed origins for the API credential identified in the path.',
   arguments: listAllCompanyAllowedOriginsRequestObject,

--- a/typescript/src/tools/management/apiCredentials/index.ts
+++ b/typescript/src/tools/management/apiCredentials/index.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { Client, ManagementAPI } from '@adyen/api-library';
 import { Tool } from '../../types.js';
+import { readOnly } from '../../annotations.js';
 
 const listAllMerchantApiCredentialsRequestObject = z.object({
   merchantId: z
@@ -43,6 +44,7 @@ const listAllMerchantApiCredentials = async (
 
 export const listAllMerchantApiCredentialsTool: Tool = {
   name: 'list_all_merchant_api_credentials',
+  annotations: readOnly('List merchant API credentials'),
   description:
     'Returns the list of API credentials for the merchant account. The list is grouped into pages as defined by the query parameters.',
   arguments: listAllMerchantApiCredentialsRequestObject,
@@ -90,6 +92,7 @@ const listAllCompanyApiCredentials = async (
 
 export const listAllCompanyApiCredentialsTool: Tool = {
   name: 'list_all_company_api_credentials',
+  annotations: readOnly('List company API credentials'),
   description:
     'Returns the list of API credentials for the company account. The list is grouped into pages as defined by the query parameters.',
   arguments: listAllCompanyApiCredentialsRequestObject,

--- a/typescript/src/tools/management/paymentMethods/index.ts
+++ b/typescript/src/tools/management/paymentMethods/index.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { Client, ManagementAPI } from '@adyen/api-library';
 import { Tool } from '../../types.js';
+import { readOnly } from '../../annotations.js';
 import {
   GET_PAYMENT_METHODS_DETAILS_MERCHANT,
   GET_PAYMENT_METHODS_DETAILS_MERCHANT_DESCRIPTION,
@@ -41,6 +42,7 @@ const listAllPaymentMethods = async (
 
 export const listAllPaymentMethodsMerchant: Tool = {
   name: LIST_ALL_PAYMENT_METHODS_MERCHANT,
+  annotations: readOnly('List merchant payment methods'),
   description: LIST_ALL_PAYMENT_METHODS_MERCHANT_DESCRIPTION,
   arguments: listAllPaymentMethodsRequestObject,
   invoke: listAllPaymentMethods,
@@ -73,6 +75,7 @@ const getPaymentMethodsDetails = async (
 
 export const getPaymentMethodsDetailsMerchant: Tool = {
   name: GET_PAYMENT_METHODS_DETAILS_MERCHANT,
+  annotations: readOnly('Get merchant payment method details'),
   description: GET_PAYMENT_METHODS_DETAILS_MERCHANT_DESCRIPTION,
   arguments: getPaymentMethodsRequestObject,
   invoke: getPaymentMethodsDetails,

--- a/typescript/src/tools/management/terminals/index.ts
+++ b/typescript/src/tools/management/terminals/index.ts
@@ -4,6 +4,7 @@ import { ScheduleTerminalActionsRequest } from '@adyen/api-library/lib/src/typin
 import { TerminalSettings } from '@adyen/api-library/lib/src/typings/management/terminalSettings.js';
 import * as constants from './constants.js'; // Group constants under a namespace
 import * as schemas from './schemas.js';
+import { readOnly, writes } from '../../annotations.js';
 import { createTool } from './toolFactory.js';
 
 // =================================================================
@@ -35,6 +36,7 @@ async function resolveCompanyId(
 
 const createTerminalActionTool = createTool({
   name: constants.CREATE_TERMINAL_ACTION_NAME,
+  annotations: writes('Create terminal action', true),
   description: constants.CREATE_TERMINAL_ACTION_DESCRIPTION,
   schema: {
     ...schemas.scheduleTerminalActionsRequestSchema.shape,
@@ -47,6 +49,7 @@ const createTerminalActionTool = createTool({
 
 const getAndroidAppTool = createTool({
   name: constants.GET_ANDROID_APP_NAME,
+  annotations: readOnly('Get Android app'),
   description: constants.GET_ANDROID_APP_DESCRIPTION,
   schema: {
     id: z.string().describe('The unique identifier of the Android app.'),
@@ -62,6 +65,7 @@ const getAndroidAppTool = createTool({
 
 const getTerminalSettingsTool = createTool({
   name: constants.GET_TERMINAL_SETTINGS_NAME,
+  annotations: readOnly('Get terminal settings'),
   description: constants.GET_TERMINAL_SETTINGS_DESCRIPTION,
   schema: {
     level: z
@@ -92,6 +96,7 @@ const getTerminalSettingsTool = createTool({
 
 const listAndroidAppsTool = createTool({
   name: constants.LIST_ANDROID_APPS_NAME,
+  annotations: readOnly('List Android apps'),
   description: constants.LIST_ANDROID_APPS_DESCRIPTION,
   schema: {
     companyId: z
@@ -130,6 +135,7 @@ const listAndroidAppsTool = createTool({
 
 const listAndroidCertificatesTool = createTool({
   name: constants.LIST_ANDROID_CERTIFICATES_NAME,
+  annotations: readOnly('List Android certificates'),
   description: constants.LIST_ANDROID_CERTIFICATES_DESCRIPTION,
   schema: {
     companyId: z
@@ -163,6 +169,7 @@ const listAndroidCertificatesTool = createTool({
 
 const listTerminalsTool = createTool({
   name: constants.LIST_TERMINALS_NAME,
+  annotations: readOnly('List terminals'),
   description: constants.LIST_TERMINALS_DESCRIPTION,
   schema: {
     searchQuery: z
@@ -227,6 +234,7 @@ const listTerminalsTool = createTool({
 
 const listTerminalActionsTool = createTool({
   name: constants.LIST_TERMINAL_ACTIONS_NAME,
+  annotations: readOnly('List terminal actions'),
   description: constants.LIST_TERMINAL_ACTIONS_DESCRIPTION,
   schema: {
     companyId: z
@@ -269,6 +277,7 @@ const listTerminalActionsTool = createTool({
 
 const reassignTerminalTool = createTool({
   name: constants.REASSIGN_TERMINAL_NAME,
+  annotations: writes('Reassign terminal', true),
   description: constants.REASSIGN_TERMINAL_DESCRIPTION,
   schema: {
     terminalId: z
@@ -307,6 +316,7 @@ const reassignTerminalTool = createTool({
 
 const updateTerminalSettingsTool = createTool({
   name: constants.UPDATE_TERMINAL_SETTINGS_NAME,
+  annotations: writes('Update terminal settings', true),
   description: constants.UPDATE_TERMINAL_SETTINGS_DESCRIPTION,
   schema: {
     level: z

--- a/typescript/src/tools/management/terminals/index.ts
+++ b/typescript/src/tools/management/terminals/index.ts
@@ -36,7 +36,8 @@ async function resolveCompanyId(
 
 const createTerminalActionTool = createTool({
   name: constants.CREATE_TERMINAL_ACTION_NAME,
-  annotations: writes('Create terminal action', true),
+  // Uninstall actions cannot be retracted through the public API once confirmed.
+  annotations: writes('Create terminal action', { destructive: true }),
   description: constants.CREATE_TERMINAL_ACTION_DESCRIPTION,
   schema: {
     ...schemas.scheduleTerminalActionsRequestSchema.shape,
@@ -277,7 +278,7 @@ const listTerminalActionsTool = createTool({
 
 const reassignTerminalTool = createTool({
   name: constants.REASSIGN_TERMINAL_NAME,
-  annotations: writes('Reassign terminal', true),
+  annotations: writes('Reassign terminal', { destructive: true }),
   description: constants.REASSIGN_TERMINAL_DESCRIPTION,
   schema: {
     terminalId: z
@@ -316,7 +317,11 @@ const reassignTerminalTool = createTool({
 
 const updateTerminalSettingsTool = createTool({
   name: constants.UPDATE_TERMINAL_SETTINGS_NAME,
-  annotations: writes('Update terminal settings', true),
+  // Explicit null values remove stored settings even though omitted fields are unchanged.
+  annotations: writes('Update terminal settings', {
+    destructive: true,
+    idempotent: true,
+  }),
   description: constants.UPDATE_TERMINAL_SETTINGS_DESCRIPTION,
   schema: {
     level: z

--- a/typescript/src/tools/management/terminals/toolFactory.ts
+++ b/typescript/src/tools/management/terminals/toolFactory.ts
@@ -1,11 +1,13 @@
 import { z } from 'zod';
 import { Client, ManagementAPI } from '@adyen/api-library';
+import { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 import { Tool } from '../../types.js';
 
 // The generic factory function to create any tool using ManagementAPI
 export function createTool<T extends z.ZodRawShape>(config: {
   name: string;
   description: string;
+  annotations: ToolAnnotations;
   schema: T;
   // This function contains the unique API call for the tool
   apiCall: (api: ManagementAPI, args: z.infer<z.ZodObject<T>>) => Promise<any>;
@@ -35,6 +37,7 @@ export function createTool<T extends z.ZodRawShape>(config: {
   return {
     name: config.name,
     description: config.description,
+    annotations: config.annotations,
     arguments: argumentSchema,
     invoke: invoke as (client: Client, args: any) => Promise<any>,
   };

--- a/typescript/src/tools/management/users/index.ts
+++ b/typescript/src/tools/management/users/index.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { Client, ManagementAPI } from '@adyen/api-library';
 import { Tool } from '../../types.js';
+import { readOnly } from '../../annotations.js';
 
 const listCompanyUsersRequestObject = z.object({
   companyId: z
@@ -48,6 +49,7 @@ const listCompanyUsers = async (
 
 export const listCompanyUsersTool: Tool = {
   name: 'list_company_users',
+  annotations: readOnly('List company users'),
   description:
     'Returns the list of users for the companyId identified in the path.',
   arguments: listCompanyUsersRequestObject,
@@ -83,6 +85,7 @@ const getCompanyUserDetails = async (
 
 export const getCompanyUserDetailsTool: Tool = {
   name: 'get_company_user_details',
+  annotations: readOnly('Get company user details'),
   description:
     'Returns user details for the userId and the companyId identified in the path.',
   arguments: getCompanyUserDetailsRequestObject,
@@ -133,6 +136,7 @@ const listMerchantUsers = async (
 
 export const listMerchantUsersTool: Tool = {
   name: 'list_merchant_users',
+  annotations: readOnly('List merchant users'),
   description:
     'Returns a list of users associated with the merchantId specified in the path.',
   arguments: listMerchantUsersRequestObject,
@@ -166,6 +170,7 @@ const getMerchantUserDetails = async (
 
 export const getMerchantUserDetailsTool: Tool = {
   name: 'get_merchant_user_details',
+  annotations: readOnly('Get merchant user details'),
   description:
     'Returns user details for the userId and the merchantId specified in the path.',
   arguments: getMerchantUserDetailsRequestObject,

--- a/typescript/src/tools/management/webhooks/index.ts
+++ b/typescript/src/tools/management/webhooks/index.ts
@@ -184,7 +184,7 @@ const testMerchantWebhook = async (
 
 export const testMerchantWebhookTool: Tool = {
   name: TEST_MERCHANT_WEBHOOK,
-  annotations: writes('Test merchant webhook', false),
+  annotations: writes('Test merchant webhook', { destructive: false }),
   description: TEST_MERCHANT_WEBHOOK_DESCRIPTION,
   arguments: testMerchantWebhookRequestObject,
   invoke: testMerchantWebhook,
@@ -220,7 +220,7 @@ const testCompanyWebhook = async (
 
 export const testCompanyWebhookTool: Tool = {
   name: TEST_COMPANY_WEBHOOK,
-  annotations: writes('Test company webhook', false),
+  annotations: writes('Test company webhook', { destructive: false }),
   description: TEST_COMPANY_WEBHOOK_DESCRIPTION,
   arguments: testCompanyWebhookRequestObject,
   invoke: testCompanyWebhook,

--- a/typescript/src/tools/management/webhooks/index.ts
+++ b/typescript/src/tools/management/webhooks/index.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { Client, ManagementAPI } from '@adyen/api-library';
 import { Tool } from '../../types.js';
+import { readOnly, writes } from '../../annotations.js';
 import {
   GET_COMPANY_WEBHOOK,
   GET_COMPANY_WEBHOOK_DESCRIPTION,
@@ -45,6 +46,7 @@ const listAllMerchantWebhooks = async (
 
 export const listAllMerchantWebhooksTool: Tool = {
   name: LIST_ALL_MERCHANT_WEBHOOKS,
+  annotations: readOnly('List merchant webhooks'),
   description: LIST_ALL_MERCHANT_WEBHOOKS_DESCRIPTION,
   arguments: listAllMerchantWebhooksRequestObject,
   invoke: listAllMerchantWebhooks,
@@ -79,6 +81,7 @@ const getMerchantWebhook = async (
 
 export const getMerchantWebhookTool: Tool = {
   name: GET_MERCHANT_WEBHOOK,
+  annotations: readOnly('Get merchant webhook'),
   description: GET_MERCHANT_WEBHOOK_DESCRIPTION,
   arguments: getMerchantWebhookRequestObject,
   invoke: getMerchantWebhook,
@@ -113,6 +116,7 @@ const listAllCompanyWebhooks = async (
 
 export const listAllCompanyWebhooksTool: Tool = {
   name: LIST_ALL_COMPANY_WEBHOOKS,
+  annotations: readOnly('List company webhooks'),
   description: LIST_ALL_COMPANY_WEBHOOKS_DESCRIPTION,
   arguments: listAllCompanyWebhooksRequestObject,
   invoke: listAllCompanyWebhooks,
@@ -145,6 +149,7 @@ const getCompanyWebhook = async (
 
 export const getCompanyWebhookTool: Tool = {
   name: GET_COMPANY_WEBHOOK,
+  annotations: readOnly('Get company webhook'),
   description: GET_COMPANY_WEBHOOK_DESCRIPTION,
   arguments: getCompanyWebhookRequestObject,
   invoke: getCompanyWebhook,
@@ -179,6 +184,7 @@ const testMerchantWebhook = async (
 
 export const testMerchantWebhookTool: Tool = {
   name: TEST_MERCHANT_WEBHOOK,
+  annotations: writes('Test merchant webhook', false),
   description: TEST_MERCHANT_WEBHOOK_DESCRIPTION,
   arguments: testMerchantWebhookRequestObject,
   invoke: testMerchantWebhook,
@@ -214,6 +220,7 @@ const testCompanyWebhook = async (
 
 export const testCompanyWebhookTool: Tool = {
   name: TEST_COMPANY_WEBHOOK,
+  annotations: writes('Test company webhook', false),
   description: TEST_COMPANY_WEBHOOK_DESCRIPTION,
   arguments: testCompanyWebhookRequestObject,
   invoke: testCompanyWebhook,

--- a/typescript/src/tools/types.ts
+++ b/typescript/src/tools/types.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { Client } from '@adyen/api-library';
+import { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 
 export interface Tool {
   /**
@@ -8,6 +9,7 @@ export interface Tool {
    */
   name: string;
   description: string;
+  annotations: ToolAnnotations;
   arguments: z.ZodObject<z.ZodRawShape>;
   invoke: (adyenClient: Client, args: any) => Promise<any>;
 }

--- a/typescript/test/tools.test.ts
+++ b/typescript/test/tools.test.ts
@@ -10,7 +10,101 @@ import {
 import { AdyenConfig } from '../src/configurations/configurations.js';
 import { getActiveTools, tools } from '../src/tools/tools';
 
+const expectedToolAnnotations: Record<
+  string,
+  { readOnlyHint: boolean; destructiveHint: boolean }
+> = {
+  create_payment_links: {
+    readOnlyHint: false,
+    destructiveHint: false,
+  },
+  get_payment_link: { readOnlyHint: true, destructiveHint: false },
+  update_payment_link: { readOnlyHint: false, destructiveHint: true },
+  refund_payment: { readOnlyHint: false, destructiveHint: true },
+  create_payment_session: {
+    readOnlyHint: false,
+    destructiveHint: false,
+  },
+  get_payment_session: { readOnlyHint: true, destructiveHint: false },
+  get_payment_methods: { readOnlyHint: true, destructiveHint: false },
+  list_merchant_accounts: { readOnlyHint: true, destructiveHint: false },
+  get_merchant_account: { readOnlyHint: true, destructiveHint: false },
+  cancel_payment: { readOnlyHint: false, destructiveHint: true },
+  create_terminal_action: { readOnlyHint: false, destructiveHint: true },
+  get_android_app: { readOnlyHint: true, destructiveHint: false },
+  get_terminal_settings: { readOnlyHint: true, destructiveHint: false },
+  list_android_apps: { readOnlyHint: true, destructiveHint: false },
+  list_android_certificates: { readOnlyHint: true, destructiveHint: false },
+  list_terminals: { readOnlyHint: true, destructiveHint: false },
+  list_terminal_actions: { readOnlyHint: true, destructiveHint: false },
+  reassign_terminal: { readOnlyHint: false, destructiveHint: true },
+  update_terminal_settings: { readOnlyHint: false, destructiveHint: true },
+  create_hosted_onboarding_link: {
+    readOnlyHint: false,
+    destructiveHint: false,
+  },
+  get_legal_entity: { readOnlyHint: true, destructiveHint: false },
+  get_account_holder: { readOnlyHint: true, destructiveHint: false },
+  list_all_company_webhooks: { readOnlyHint: true, destructiveHint: false },
+  get_company_webhook: { readOnlyHint: true, destructiveHint: false },
+  test_company_webhook: { readOnlyHint: false, destructiveHint: false },
+  list_all_merchant_webhooks: { readOnlyHint: true, destructiveHint: false },
+  get_merchant_webhook: { readOnlyHint: true, destructiveHint: false },
+  test_merchant_webhook: { readOnlyHint: false, destructiveHint: false },
+  list_company_users: { readOnlyHint: true, destructiveHint: false },
+  get_company_user_details: { readOnlyHint: true, destructiveHint: false },
+  list_merchant_users: { readOnlyHint: true, destructiveHint: false },
+  get_merchant_user_details: { readOnlyHint: true, destructiveHint: false },
+  list_all_payment_methods_merchant: {
+    readOnlyHint: true,
+    destructiveHint: false,
+  },
+  get_payment_methods_details_merchant: {
+    readOnlyHint: true,
+    destructiveHint: false,
+  },
+  list_all_company_api_credentials: {
+    readOnlyHint: true,
+    destructiveHint: false,
+  },
+  list_all_merchant_api_credentials: {
+    readOnlyHint: true,
+    destructiveHint: false,
+  },
+  list_all_company_allowed_origins: {
+    readOnlyHint: true,
+    destructiveHint: false,
+  },
+  list_all_merchant_allowed_origins: {
+    readOnlyHint: true,
+    destructiveHint: false,
+  },
+};
+
 describe('tools', () => {
+  it('classifies every exposed tool with MCP annotations', () => {
+    const toolNames = tools.map((tool) => tool.name);
+
+    expect(toolNames).toHaveLength(Object.keys(expectedToolAnnotations).length);
+    expect(new Set(toolNames).size).toBe(toolNames.length);
+    expect(new Set(toolNames)).toEqual(
+      new Set(Object.keys(expectedToolAnnotations)),
+    );
+
+    for (const tool of tools) {
+      expect(tool.annotations.title).toEqual(expect.any(String));
+      expect(tool.annotations.title).not.toHaveLength(0);
+      expect(tool.annotations).toMatchObject({
+        ...expectedToolAnnotations[tool.name],
+        idempotentHint: tool.annotations.readOnlyHint,
+        openWorldHint: true,
+      });
+      expect(
+        tool.annotations.readOnlyHint && tool.annotations.destructiveHint,
+      ).toBe(false);
+    }
+  });
+
   describe('getActiveTools', () => {
     const totalToolsCount = tools.length;
     const createConfig = (

--- a/typescript/test/tools.test.ts
+++ b/typescript/test/tools.test.ts
@@ -10,75 +10,66 @@ import {
 import { AdyenConfig } from '../src/configurations/configurations.js';
 import { getActiveTools, tools } from '../src/tools/tools';
 
-const expectedToolAnnotations: Record<
-  string,
-  { readOnlyHint: boolean; destructiveHint: boolean }
-> = {
-  create_payment_links: {
-    readOnlyHint: false,
-    destructiveHint: false,
-  },
-  get_payment_link: { readOnlyHint: true, destructiveHint: false },
-  update_payment_link: { readOnlyHint: false, destructiveHint: true },
-  refund_payment: { readOnlyHint: false, destructiveHint: true },
-  create_payment_session: {
-    readOnlyHint: false,
-    destructiveHint: false,
-  },
-  get_payment_session: { readOnlyHint: true, destructiveHint: false },
-  get_payment_methods: { readOnlyHint: true, destructiveHint: false },
-  list_merchant_accounts: { readOnlyHint: true, destructiveHint: false },
-  get_merchant_account: { readOnlyHint: true, destructiveHint: false },
-  cancel_payment: { readOnlyHint: false, destructiveHint: true },
-  create_terminal_action: { readOnlyHint: false, destructiveHint: true },
-  get_android_app: { readOnlyHint: true, destructiveHint: false },
-  get_terminal_settings: { readOnlyHint: true, destructiveHint: false },
-  list_android_apps: { readOnlyHint: true, destructiveHint: false },
-  list_android_certificates: { readOnlyHint: true, destructiveHint: false },
-  list_terminals: { readOnlyHint: true, destructiveHint: false },
-  list_terminal_actions: { readOnlyHint: true, destructiveHint: false },
-  reassign_terminal: { readOnlyHint: false, destructiveHint: true },
-  update_terminal_settings: { readOnlyHint: false, destructiveHint: true },
-  create_hosted_onboarding_link: {
-    readOnlyHint: false,
-    destructiveHint: false,
-  },
-  get_legal_entity: { readOnlyHint: true, destructiveHint: false },
-  get_account_holder: { readOnlyHint: true, destructiveHint: false },
-  list_all_company_webhooks: { readOnlyHint: true, destructiveHint: false },
-  get_company_webhook: { readOnlyHint: true, destructiveHint: false },
-  test_company_webhook: { readOnlyHint: false, destructiveHint: false },
-  list_all_merchant_webhooks: { readOnlyHint: true, destructiveHint: false },
-  get_merchant_webhook: { readOnlyHint: true, destructiveHint: false },
-  test_merchant_webhook: { readOnlyHint: false, destructiveHint: false },
-  list_company_users: { readOnlyHint: true, destructiveHint: false },
-  get_company_user_details: { readOnlyHint: true, destructiveHint: false },
-  list_merchant_users: { readOnlyHint: true, destructiveHint: false },
-  get_merchant_user_details: { readOnlyHint: true, destructiveHint: false },
-  list_all_payment_methods_merchant: {
-    readOnlyHint: true,
-    destructiveHint: false,
-  },
-  get_payment_methods_details_merchant: {
-    readOnlyHint: true,
-    destructiveHint: false,
-  },
-  list_all_company_api_credentials: {
-    readOnlyHint: true,
-    destructiveHint: false,
-  },
-  list_all_merchant_api_credentials: {
-    readOnlyHint: true,
-    destructiveHint: false,
-  },
-  list_all_company_allowed_origins: {
-    readOnlyHint: true,
-    destructiveHint: false,
-  },
-  list_all_merchant_allowed_origins: {
-    readOnlyHint: true,
-    destructiveHint: false,
-  },
+type ExpectedToolAnnotations = {
+  readOnlyHint: boolean;
+  destructiveHint: boolean;
+  idempotentHint: boolean;
+};
+
+const readOnly: ExpectedToolAnnotations = {
+  readOnlyHint: true,
+  destructiveHint: false,
+  idempotentHint: true,
+};
+
+const writes = (
+  destructiveHint: boolean,
+  idempotentHint = false,
+): ExpectedToolAnnotations => ({
+  readOnlyHint: false,
+  destructiveHint,
+  idempotentHint,
+});
+
+const expectedToolAnnotations: Record<string, ExpectedToolAnnotations> = {
+  create_payment_links: writes(false),
+  get_payment_link: readOnly,
+  update_payment_link: writes(true, true),
+  refund_payment: writes(true),
+  create_payment_session: writes(false),
+  get_payment_session: readOnly,
+  get_payment_methods: readOnly,
+  list_merchant_accounts: readOnly,
+  get_merchant_account: readOnly,
+  cancel_payment: writes(true),
+  create_terminal_action: writes(true),
+  get_android_app: readOnly,
+  get_terminal_settings: readOnly,
+  list_android_apps: readOnly,
+  list_android_certificates: readOnly,
+  list_terminals: readOnly,
+  list_terminal_actions: readOnly,
+  reassign_terminal: writes(true),
+  update_terminal_settings: writes(true, true),
+  create_hosted_onboarding_link: writes(false),
+  get_legal_entity: readOnly,
+  get_account_holder: readOnly,
+  list_all_company_webhooks: readOnly,
+  get_company_webhook: readOnly,
+  test_company_webhook: writes(false),
+  list_all_merchant_webhooks: readOnly,
+  get_merchant_webhook: readOnly,
+  test_merchant_webhook: writes(false),
+  list_company_users: readOnly,
+  get_company_user_details: readOnly,
+  list_merchant_users: readOnly,
+  get_merchant_user_details: readOnly,
+  list_all_payment_methods_merchant: readOnly,
+  get_payment_methods_details_merchant: readOnly,
+  list_all_company_api_credentials: readOnly,
+  list_all_merchant_api_credentials: readOnly,
+  list_all_company_allowed_origins: readOnly,
+  list_all_merchant_allowed_origins: readOnly,
 };
 
 describe('tools', () => {
@@ -96,7 +87,6 @@ describe('tools', () => {
       expect(tool.annotations.title).not.toHaveLength(0);
       expect(tool.annotations).toMatchObject({
         ...expectedToolAnnotations[tool.name],
-        idempotentHint: tool.annotations.readOnlyHint,
         openWorldHint: true,
       });
       expect(


### PR DESCRIPTION
## Summary

Adds MCP tool annotations to all exposed tools. Clients can distinguish read-only operations from writes and request confirmation for destructive operations.

- Classifies 38 tools: 25 read-only and 13 writes, including 8 destructive writes.
- Uses helpers that require each tool to declare its annotation set.
- Adds a table-driven test that fails when an exposed tool is unclassified.

## Classification decisions

- `create_terminal_action` is destructive because it can schedule an uninstall, which cannot be retracted through the public API after confirmation.
- `reassign_terminal` is destructive because it removes non-local properties and merchant/store associations, and can trigger uninstalls.
- `update_payment_link` is destructive because the only supported target state is `Expired`, which also expires its sessions.
- `update_payment_link` and `update_terminal_settings` are idempotent target-state writes.

All annotations include `openWorldHint: true` because the tools call Adyen APIs.