### PR TITLE
Add workflow to label new issues

### DIFF
--- a/.github/workflows/label_new_issues.yml
+++ b/.github/workflows/label_new_issues.yml
@@ -1,0 +1,17 @@
+name: Label New Issues
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  add-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add 'needs response' label to new issues
+        uses: actions-ecosystem/action-add-labels@1a9c3715c0037e96b97bb38cb4c4b56a1f1d4871
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: 'needs response'


### PR DESCRIPTION
**Description**
Add the same workflow used by adyen-java-api-library to automatically apply the `needs response` label when an issue is opened.

**Tested scenarios**
- Confirmed the workflow exactly matches the source workflow.
- Validated the workflow YAML syntax.

**Fixed issue**:
