### PR TITLE
Support ADYEN_API_KEY environment variable for API key configuration

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -4,8 +4,7 @@
       "type": "stdio",
       "command": "node",
       "args": [
-        "/workspaces/adyen-mcp/typescript/dist/index.js", 
-        "--adyenApiKey", "${ADYEN_API_KEY}",
+        "/workspaces/adyen-mcp/typescript/dist/index.js",
         "--env", "TEST"
       ],
       "env": {

--- a/README.md
+++ b/README.md
@@ -51,18 +51,18 @@ The [Adyen Model Context Protocol (MCP) server](https://docs.adyen.com/developme
 * Run the MCP server via `npx` with the following command:
 
 ```
-npx -y @adyen/mcp --adyenApiKey=YOUR_ADYEN_API_KEY --env=TEST
+ADYEN_API_KEY=YOUR_ADYEN_API_KEY npx -y @adyen/mcp --env=TEST
 ```
 
 If you are using the LIVE environment then you must also provide your [live URL prefix](https://docs.adyen.com/development-resources/live-endpoints/#live-url-prefix), for example:
 
 ```
-npx -y @adyen/mcp --adyenApiKey=YOUR_ADYEN_API_KEY --env=LIVE --livePrefix=YOUR_PREFIX_URL
+ADYEN_API_KEY=YOUR_ADYEN_API_KEY npx -y @adyen/mcp --env=LIVE --livePrefix=YOUR_PREFIX_URL
 ```
 
 We advise to only run a subset of tools required for your particular use case:
 ```
-npx -y @adyen/mcp --adyenApiKey=YOUR_ADYEN_API_KEY --env=TEST --tools=list_all_company_webhooks,list_all_merchant_webhooks
+ADYEN_API_KEY=YOUR_ADYEN_API_KEY npx -y @adyen/mcp --env=TEST --tools=list_all_company_webhooks,list_all_merchant_webhooks
 ```
 
 Example usage in `.vscode`:
@@ -72,7 +72,7 @@ Example usage in `.vscode`:
     "adyen-mcp-server": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@adyen/mcp", "--adyenApiKey=YOUR_ADYEN_API_KEY", "--env=TEST"],
+      "args": ["-y", "@adyen/mcp", "--env=TEST"],
       "env": {
         "ADYEN_API_KEY": "${ADYEN_API_KEY}"
       }

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -49,18 +49,18 @@ The Adyen Model Context Protocol server allows you to integrate with Adyen APIs 
 To run to the MCP server via `npx` you can execute:
 
 ```
-npx -y @adyen/mcp --adyenApiKey=YOUR_ADYEN_API_KEY --env=TEST
+ADYEN_API_KEY=YOUR_ADYEN_API_KEY npx -y @adyen/mcp --env=TEST
 ```
 
 Optionally, if the environment is LIVE then you must also provide your Merchant URL, for example:
 
 ```
-npx -y @adyen/mcp --adyenApiKey=YOUR_ADYEN_API_KEY --env=LIVE --livePrefix=YOUR_PREFIX_URL
+ADYEN_API_KEY=YOUR_ADYEN_API_KEY npx -y @adyen/mcp --env=LIVE --livePrefix=YOUR_PREFIX_URL
 ```
 
 We advise to only run a subset of tools required for your particular use case:
 ```
-npx -y @adyen/mcp --adyenApiKey=YOUR_ADYEN_API_KEY --env=TEST --tools=list_all_company_webhooks,list_all_merchant_webhooks
+ADYEN_API_KEY=YOUR_ADYEN_API_KEY npx -y @adyen/mcp --env=TEST --tools=list_all_company_webhooks,list_all_merchant_webhooks
 ```
 
 Tools include MCP annotations that identify read-only and destructive operations. Clients can use these hints to request confirmation before invoking write tools.

--- a/typescript/src/configurations/configurations.ts
+++ b/typescript/src/configurations/configurations.ts
@@ -13,7 +13,9 @@ export enum Environment {
   TEST = 'TEST',
 }
 
-const mandatoryFields = [AdyenOptionKeys.ApiKey, AdyenOptionKeys.Environment];
+export const API_KEY_ENV_VAR = 'ADYEN_API_KEY';
+
+const mandatoryFields = [AdyenOptionKeys.Environment];
 
 export type AdyenConfig = {
   [AdyenOptionKeys.ApiKey]: string;
@@ -51,6 +53,27 @@ const splitAndTrim = (input: string | undefined): string[] | undefined => {
 };
 
 function validateAdyenConfig(options: { [option: string]: any }) {
+  // Prefer the CLI flag, fall back to the environment variable so the key
+  // does not have to appear on argv (ps output, shell history, MCP host configs).
+  const apiKeyFromArg = options[AdyenOptionKeys.ApiKey];
+  if (apiKeyFromArg === undefined || apiKeyFromArg === null) {
+    options[AdyenOptionKeys.ApiKey] = process.env[API_KEY_ENV_VAR];
+  } else if (options[AdyenOptionKeys.Environment] === Environment.LIVE) {
+    console.error(
+      `Warning: for LIVE environments, set the ${API_KEY_ENV_VAR} environment variable to provide your API key securely.`,
+    );
+  }
+
+  if (
+    options[AdyenOptionKeys.ApiKey] === undefined ||
+    options[AdyenOptionKeys.ApiKey] === null ||
+    options[AdyenOptionKeys.ApiKey] === ''
+  ) {
+    throw new Error(
+      `Missing or empty API key: set the ${API_KEY_ENV_VAR} environment variable`,
+    );
+  }
+
   for (const key of mandatoryFields) {
     if (
       options[key] === undefined ||
@@ -102,7 +125,7 @@ export function getAdyenConfig(
     console.error(`  ${error.message}`);
     console.error('\nUsage examples:');
     console.error(
-      `  npx @adyen/mcp --${AdyenOptionKeys.ApiKey} <your-adyen-api-key> --${AdyenOptionKeys.Environment} <your-env>`,
+      `  ${API_KEY_ENV_VAR}=<your-adyen-api-key> npx @adyen/mcp --${AdyenOptionKeys.Environment} <your-env>`,
     );
     throw error;
   }

--- a/typescript/test/configurations.test.ts
+++ b/typescript/test/configurations.test.ts
@@ -4,10 +4,22 @@ import { MockInstance } from 'vitest';
 describe('configurations', () => {
   // Store original process.argv to restore after tests
   const originalArgv = process.argv;
+  // Store original ADYEN_API_KEY to restore after tests
+  const originalApiKeyEnv = process.env.ADYEN_API_KEY;
+
+  beforeEach(() => {
+    // Ensure tests are not affected by a real ADYEN_API_KEY in the environment
+    delete process.env.ADYEN_API_KEY;
+  });
 
   afterEach(() => {
-    // Restore original process.argv after each test
+    // Restore original process.argv and ADYEN_API_KEY after each test
     process.argv = originalArgv;
+    if (originalApiKeyEnv === undefined) {
+      delete process.env.ADYEN_API_KEY;
+    } else {
+      process.env.ADYEN_API_KEY = originalApiKeyEnv;
+    }
   });
 
   describe('getAdyenConfig', () => {
@@ -61,17 +73,87 @@ describe('configurations', () => {
       });
     });
 
+    describe('ADYEN_API_KEY environment variable fallback', () => {
+      it('should use ADYEN_API_KEY env var when --adyenApiKey is not provided', () => {
+        process.env.ADYEN_API_KEY = 'env-api-key';
+        const args = ['--env', 'TEST'];
+        const config = getAdyenConfig(args);
+
+        expect(config.adyenApiKey).toBe('env-api-key');
+        expect(config.env).toBe('TEST');
+      });
+
+      it('should prefer --adyenApiKey over the ADYEN_API_KEY env var', () => {
+        process.env.ADYEN_API_KEY = 'env-api-key';
+        const args = ['--adyenApiKey', 'argv-api-key', '--env', 'TEST'];
+        const config = getAdyenConfig(args);
+
+        expect(config.adyenApiKey).toBe('argv-api-key');
+      });
+
+      it('should throw error when no API key is provided', () => {
+        const args = ['--env', 'TEST'];
+
+        expect(() => getAdyenConfig(args)).toThrow(/ADYEN_API_KEY/);
+      });
+
+      it('should warn when the API key is passed via argv in LIVE environment', () => {
+        const consoleSpy = vi
+          .spyOn(console, 'error')
+          .mockImplementation(() => {});
+        try {
+          const args = [
+            '--adyenApiKey',
+            'live-api-key',
+            '--env',
+            'LIVE',
+            '--livePrefix',
+            'https://example.adyen.com',
+          ];
+          const config = getAdyenConfig(args);
+
+          expect(config.adyenApiKey).toBe('live-api-key');
+          expect(consoleSpy).toHaveBeenCalledWith(
+            expect.stringMatching(/ADYEN_API_KEY/),
+          );
+        } finally {
+          consoleSpy.mockRestore();
+        }
+      });
+
+      it('should not warn when the API key comes from the env var in LIVE environment', () => {
+        process.env.ADYEN_API_KEY = 'env-live-key';
+        const consoleSpy = vi
+          .spyOn(console, 'error')
+          .mockImplementation(() => {});
+        try {
+          const args = [
+            '--env',
+            'LIVE',
+            '--livePrefix',
+            'https://example.adyen.com',
+          ];
+          const config = getAdyenConfig(args);
+
+          expect(config.adyenApiKey).toBe('env-live-key');
+          expect(consoleSpy).not.toHaveBeenCalled();
+        } finally {
+          consoleSpy.mockRestore();
+        }
+      });
+    });
+
     describe('validation errors', () => {
       it('should throw error when apiKey is missing', () => {
         const args = ['--env', 'TEST'];
 
-        expect(() => getAdyenConfig(args)).toThrow(/adyenApiKey/i);
+        expect(() => getAdyenConfig(args)).toThrow(/ADYEN_API_KEY/);
       });
 
       it('should throw error when apiKey is empty string', () => {
         const args = ['--adyenApiKey', '', '--env', 'TEST'];
 
-        expect(() => getAdyenConfig(args)).toThrow(/adyenApiKey/i);
+        expect(() => getAdyenConfig(args)).toThrow(/ADYEN_API_KEY/);
       });
 
       it('should throw error when environment is invalid', () => {
@@ -153,7 +235,7 @@ describe('configurations', () => {
 
         expect(() => getAdyenConfig(args)).toThrow();
         expect(consoleSpy).toHaveBeenCalledWith(
-          expect.stringMatching(/adyenApiKey/i),
+          expect.stringMatching(/ADYEN_API_KEY/),
         );
       });
     });
@@ -163,7 +245,7 @@ describe('configurations', () => {
         const args: string[] = [];
 
         // Should use default TEST environment but fail on missing API key
-        expect(() => getAdyenConfig(args)).toThrow(/adyenApiKey/i);
+        expect(() => getAdyenConfig(args)).toThrow(/ADYEN_API_KEY/);
       });
 
       it('should handle null values', () => {


### PR DESCRIPTION
Passing the key via --adyenApiKey exposes it through process listings, shell history, and MCP host config files. Fall back to the ADYEN_API_KEY environment variable when the flag is absent, warn when a LIVE key is passed via argv, and update docs and .vscode/mcp.json to use the env var.