### PR TITLE
Bump version to 0.6.0

### DIFF
--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adyen/mcp",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adyen/mcp",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@adyen/api-library": "^27.0.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adyen/mcp",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "main": "dist/index.js",
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
New version, release changes:
- added tool annotations
- move ADYEN_API_KEY to env variable (still support CLI for backward compatibility)


### Test results
1. Automated checks

Build: clean (tsc)
Tests: 49/49 passed across 4 files (configurations, tools annotation assertions, error-sanitization, build)
Lint: clean

2. ADYEN_API_KEY resolution (the env var change)

No key anywhere → correct error: "Missing or empty API key: set the ADYEN_API_KEY environment variable"
Empty ADYEN_API_KEY → same error
Env var alone → server starts (also proven by the LIVE test reaching the prefix check)
--env=LIVE without prefix → prefix error
--env=LIVE with --adyenApiKey flag → security warning printed to stderr

3. Tool annotations (live over stdio JSON-RPC)

All 38 tools carry annotations, none missing
Read tools (get_*, list_*): readOnlyHint: true, idempotentHint: true
Target-state writes (update_terminal_settings, update_payment_link): idempotentHint: true
Creates (create_payment_session, create_payment_links, etc.): idempotentHint: false
Destructive flags correct on refunds, cancels, reassignment, settings updates
tools/call list_merchant_accounts with the mock key → 401 from Adyen TEST, proving end-to-end wiring; zod schema validation also confirmed (rejects missing pageSize/pageNumber)

4. Packaged release

npm pack → 
adyen-mcp-0.6.0.tgz
 (36 files, version 0.6.0 inside)
Packed bin reproduces all key-resolution behavior and serves all 38 tools over MCP
